### PR TITLE
brew cask install is deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ You can download the latest release over on the [Releases Page](https://github.c
 
 #### Using Homebrew
 
-    brew cask install secretive
+    brew install secretive
 
 ### FAQ
 


### PR DESCRIPTION
When running `brew cask install secretive`, you get this error:

```shell
$ brew cask install secretive
Error: Calling brew cask install is disabled! Use brew install [--cask] instead.
```

This PR updates the docs to use `brew install` instead of `brew cask install`