### PR TITLE
Remove 24h unlock duration

### DIFF
--- a/Sources/SecretAgent/Notifier.swift
+++ b/Sources/SecretAgent/Notifier.swift
@@ -18,8 +18,7 @@ class Notifier {
         let rawDurations = [
             Measurement(value: 1, unit: UnitDuration.minutes),
             Measurement(value: 5, unit: UnitDuration.minutes),
-            Measurement(value: 1, unit: UnitDuration.hours),
-            Measurement(value: 24, unit: UnitDuration.hours)
+            Measurement(value: 1, unit: UnitDuration.hours)
         ]
 
         let doNotPersistAction = UNNotificationAction(identifier: Constants.doNotPersistActionIdentitifier, title: "Do Not Unlock", options: [])


### PR DESCRIPTION
Still haven't been able to get really long durations working reliably, so I'm removing the 24h option.