### PR TITLE
Add sha-256 checksums to auditable build output

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -40,8 +40,12 @@ jobs:
       run: xcrun notarytool submit --key ~/.private_keys/AuthKey_$APPLE_API_KEY_ID.p8 --key-id $APPLE_API_KEY_ID --issuer $APPLE_API_ISSUER Secretive.zip
     - name: Document SHAs
       run: |
+            echo "sha-512:"
             shasum -a 512 Secretive.zip
             shasum -a 512 Archive.zip
+            echo "sha-256:"
+            shasum -a 256 Secretive.zip
+            shasum -a 256 Archive.zip
     - name: Upload App to Artifacts
       uses: actions/upload-artifact@v1
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,8 +64,12 @@ jobs:
       run: xcrun notarytool submit --key ~/.private_keys/AuthKey_$APPLE_API_KEY_ID.p8 --key-id $APPLE_API_KEY_ID --issuer $APPLE_API_ISSUER Secretive.zip
     - name: Document SHAs
       run: |
+            echo "sha-512:"
             shasum -a 512 Secretive.zip
             shasum -a 512 Archive.zip
+            echo "sha-256:"
+            shasum -a 256 Secretive.zip
+            shasum -a 256 Archive.zip
     - name: Create Release
       id: create_release
       uses: actions/create-release@v1


### PR DESCRIPTION
This pull request adds a sha-256 checksum to the "Document SHAs" step of the build process to make it easier to verify that the checksum embedded in the [homebrew formula](https://github.com/Homebrew/homebrew-cask/blob/f616fe0cb0ff463480bd14213c7b9c65cf6c0a2e/Casks/secretive.rb) is the same as the checksum of the file built by GitHub Actions.

I've not actually been able to run this code in GitHub Actions (there are too many secrets to set up, as noted in #343) but the changes are simple enough that they should just work.