### PR TITLE
Add line about help/setup tool to FAQ

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -12,6 +12,10 @@ Secretive relies on the `SSH_AUTH_SOCK` environment variable being respected. Th
 
 Please run `ssh -Tv git@github.com` in your terminal and paste the output in a [new GitHub issue](https://github.com/maxgoedjen/secretive/issues/new) with a description of your issue.
 
+### Secretive was working for me, but now it has stopped
+
+Try running the "Setup Secretive" process by clicking on "Help", then "Setup Secretive." If that doesn't work, follow the process above.
+
 ### Secretive prompts me to type my password instead of using my Apple Watch
 
 1) Make sure you have enabled "Use your Apple Watch to unlock apps and your Mac" in System Preferences --> Security & Privacy:


### PR DESCRIPTION
It happens so infrequently that I always forget and have to go looking for it, but every so often Secretive will stop working. As discussed [here](https://github.com/maxgoedjen/secretive/issues/363#issuecomment-1057863773) there is a Setup flow available in the Help menu that is undocumented, which solves the problem basically every time. This PR adds a line about it to the FAQ so that I (and anyone else with a similar problem) can find it and be reminded. Happy to rephrase or edit etc but I think this'll cut down on bug reports too!