### PR TITLE
Initial openssh certificate support

### DIFF
--- a/Sources/Packages/Sources/SecretAgentKit/Agent.swift
+++ b/Sources/Packages/Sources/SecretAgentKit/Agent.swift
@@ -105,13 +105,17 @@ extension Agent {
         var keyData = Data()
 
         for secret in secrets {
-            var keyBlob = writer.data(secret: secret)
-            var curveData = writer.curveType(for: secret.algorithm, length: secret.keySize).data(using: .utf8)!
-
+            let keyBlob: Data
+            let curveData: Data
+            
             if let (certBlob, certName) = try? checkForCert(secret: secret) {
                 keyBlob = certBlob
                 curveData = certName
+            } else {
+                keyBlob = writer.data(secret: secret)
+                curveData = writer.curveType(for: secret.algorithm, length: secret.keySize).data(using: .utf8)!
             }
+            
             keyData.append(writer.lengthAndData(of: keyBlob))
             keyData.append(writer.lengthAndData(of: curveData))
             


### PR DESCRIPTION
This change adds initial OpenSSH certificate support and closes https://github.com/maxgoedjen/secretive/issues/269

If a a cert file exists for a public key in the 'PublicKeys' directory, SecretAgent will use it instead of the PublicKey. 

For example if Secretive creates a key with the path `~/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/PublicKeys/266b0718b08bc8653c885ae41534e1c0.pub` it will check if `~/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/PublicKeys/266b0718b08bc8653c885ae41534e1c0-cert.pub` exists, and return the contents as an available identity.

Upon a signing request it will attempt to check if the signing request is actually for a certificate, resolve it and sign using the correct secret instead.

This is probably pretty rough, im not a Swift dev normally, i just really wanted this feature in :)

Please let me know what changes need to occur to get this merged in.

