### PR TITLE
Fix for SecretAgent acting as if it has no keys after updating macOS

### DIFF
--- a/Sources/Packages/Sources/SecretKit/Erasers/AnySecretStore.swift
+++ b/Sources/Packages/Sources/SecretKit/Erasers/AnySecretStore.swift
@@ -12,6 +12,7 @@ public class AnySecretStore: SecretStore {
     private let _sign: (Data, AnySecret, SigningRequestProvenance) throws -> Data
     private let _existingPersistedAuthenticationContext: (AnySecret) -> PersistedAuthenticationContext?
     private let _persistAuthentication: (AnySecret, TimeInterval) throws -> Void
+    private let _reloadSecrets: () -> Void
 
     private var sink: AnyCancellable?
 
@@ -24,6 +25,7 @@ public class AnySecretStore: SecretStore {
         _sign = { try secretStore.sign(data: $0, with: $1.base as! SecretStoreType.SecretType, for: $2) }
         _existingPersistedAuthenticationContext = { secretStore.existingPersistedAuthenticationContext(secret: $0.base as! SecretStoreType.SecretType) }
         _persistAuthentication = { try secretStore.persistAuthentication(secret: $0.base as! SecretStoreType.SecretType, forDuration: $1) }
+        _reloadSecrets = { secretStore.reloadSecrets() }
         sink = secretStore.objectWillChange.sink { _ in
             self.objectWillChange.send()
         }
@@ -55,6 +57,10 @@ public class AnySecretStore: SecretStore {
 
     public func persistAuthentication(secret: AnySecret, forDuration duration: TimeInterval) throws {
         try _persistAuthentication(secret, duration)
+    }
+
+    public func reloadSecrets() {
+        _reloadSecrets()
     }
 
 }

--- a/Sources/Packages/Sources/SecretKit/Types/SecretStore.swift
+++ b/Sources/Packages/Sources/SecretKit/Types/SecretStore.swift
@@ -36,6 +36,9 @@ public protocol SecretStore: ObservableObject, Identifiable {
     ///  - Note: This is used for temporarily unlocking access to a secret which would otherwise require authentication every single use. This is useful for situations where the user anticipates several rapid accesses to a authorization-guarded secret.
     func persistAuthentication(secret: SecretType, forDuration duration: TimeInterval) throws
 
+    /// Requests that the store reload secrets from any backing store, if neccessary.
+    func reloadSecrets()
+
 }
 
 /// A SecretStore that the Secretive admin app can modify.

--- a/Sources/Packages/Sources/SecureEnclaveSecretKit/SecureEnclaveStore.swift
+++ b/Sources/Packages/Sources/SecureEnclaveSecretKit/SecureEnclaveStore.swift
@@ -164,7 +164,7 @@ extension SecureEnclave {
         }
 
         public func reloadSecrets() {
-            reloadSecretsInternal()
+            reloadSecretsInternal(notifyAgent: false)
         }
 
     }
@@ -176,11 +176,14 @@ extension SecureEnclave.Store {
     /// Reloads all secrets from the store.
     /// - Parameter notifyAgent: A boolean indicating whether a distributed notification should be posted, notifying other processes (ie, the SecretAgent) to reload their stores as well.
     private func reloadSecretsInternal(notifyAgent: Bool = true) {
+        let before = secrets
         secrets.removeAll()
         loadSecrets()
-        NotificationCenter.default.post(name: .secretStoreReloaded, object: self)
-        if notifyAgent {
-            DistributedNotificationCenter.default().postNotificationName(.secretStoreUpdated, object: nil, deliverImmediately: true)
+        if secrets != before {
+            NotificationCenter.default.post(name: .secretStoreReloaded, object: self)
+            if notifyAgent {
+                DistributedNotificationCenter.default().postNotificationName(.secretStoreUpdated, object: nil, deliverImmediately: true)
+            }
         }
     }
 

--- a/Sources/Packages/Sources/SecureEnclaveSecretKit/SecureEnclaveStore.swift
+++ b/Sources/Packages/Sources/SecureEnclaveSecretKit/SecureEnclaveStore.swift
@@ -24,7 +24,7 @@ extension SecureEnclave {
         /// Initializes a Store.
         public init() {
             DistributedNotificationCenter.default().addObserver(forName: .secretStoreUpdated, object: nil, queue: .main) { _ in
-                self.reloadSecrets(notifyAgent: false)
+                self.reloadSecretsInternal(notifyAgent: false)
             }
             loadSecrets()
         }
@@ -68,7 +68,7 @@ extension SecureEnclave {
                 throw KeychainError(statusCode: nil)
             }
             try savePublicKey(publicKey, name: name)
-            reloadSecrets()
+            reloadSecretsInternal()
         }
 
         public func delete(secret: Secret) throws {
@@ -80,7 +80,7 @@ extension SecureEnclave {
             if status != errSecSuccess {
                 throw KeychainError(statusCode: status)
             }
-            reloadSecrets()
+            reloadSecretsInternal()
         }
 
         public func update(secret: Secret, name: String) throws {
@@ -97,7 +97,7 @@ extension SecureEnclave {
             if status != errSecSuccess {
                 throw KeychainError(statusCode: status)
             }
-            reloadSecrets()
+            reloadSecretsInternal()
         }
         
         public func sign(data: Data, with secret: SecretType, for provenance: SigningRequestProvenance) throws -> Data {
@@ -163,6 +163,10 @@ extension SecureEnclave {
             }
         }
 
+        public func reloadSecrets() {
+            reloadSecretsInternal()
+        }
+
     }
 
 }
@@ -171,7 +175,7 @@ extension SecureEnclave.Store {
 
     /// Reloads all secrets from the store.
     /// - Parameter notifyAgent: A boolean indicating whether a distributed notification should be posted, notifying other processes (ie, the SecretAgent) to reload their stores as well.
-    private func reloadSecrets(notifyAgent: Bool = true) {
+    private func reloadSecretsInternal(notifyAgent: Bool = true) {
         secrets.removeAll()
         loadSecrets()
         NotificationCenter.default.post(name: .secretStoreReloaded, object: self)

--- a/Sources/Packages/Sources/SmartCardSecretKit/SmartCardStore.swift
+++ b/Sources/Packages/Sources/SmartCardSecretKit/SmartCardStore.swift
@@ -89,6 +89,15 @@ extension SmartCard {
         public func persistAuthentication(secret: SmartCard.Secret, forDuration: TimeInterval) throws {
         }
 
+        /// Reloads all secrets from the store.
+        public func reloadSecrets() {
+            DispatchQueue.main.async {
+                self.isAvailable = self.tokenID != nil
+                self.secrets.removeAll()
+                self.loadSecrets()
+            }
+        }
+
     }
 
 }
@@ -100,15 +109,6 @@ extension SmartCard.Store {
     private func smartcardRemoved(for tokenID: String? = nil) {
         self.tokenID = nil
         reloadSecrets()
-    }
-
-    /// Reloads all secrets from the store.
-    private func reloadSecrets() {
-        DispatchQueue.main.async {
-            self.isAvailable = self.tokenID != nil
-            self.secrets.removeAll()
-            self.loadSecrets()
-        }
     }
 
     /// Loads all secrets from the store.

--- a/Sources/Packages/Sources/SmartCardSecretKit/SmartCardStore.swift
+++ b/Sources/Packages/Sources/SmartCardSecretKit/SmartCardStore.swift
@@ -93,8 +93,12 @@ extension SmartCard {
         public func reloadSecrets() {
             DispatchQueue.main.async {
                 self.isAvailable = self.tokenID != nil
+                let before = self.secrets
                 self.secrets.removeAll()
                 self.loadSecrets()
+                if self.secrets != before {
+                    NotificationCenter.default.post(name: .secretStoreReloaded, object: self)
+                }
             }
         }
 

--- a/Sources/Packages/Tests/SecretAgentKitTests/StubStore.swift
+++ b/Sources/Packages/Tests/SecretAgentKitTests/StubStore.swift
@@ -78,6 +78,9 @@ extension Stub {
         public func persistAuthentication(secret: Stub.Secret, forDuration duration: TimeInterval) throws {
         }
 
+        public func reloadSecrets() {
+        }
+
     }
 
 }

--- a/Sources/Secretive/Preview Content/PreviewStore.swift
+++ b/Sources/Secretive/Preview Content/PreviewStore.swift
@@ -47,6 +47,9 @@ extension Preview {
         func persistAuthentication(secret: Preview.Secret, forDuration duration: TimeInterval) throws {
         }
 
+        func reloadSecrets() {
+        }
+
     }
 
     class StoreModifiable: Store, SecretStoreModifiable {


### PR DESCRIPTION
H/t @saagarjha for suggesting the root cause of this issue (basically, the agent being relaunched too early before the keychain has been unlocked).

I haven't been able to consistently reproduce the bug (either on VMs or real machines) – so this is a bit of a speculative fix.

Fixes #415
Fixes #426
Fixes #391 
Fixes #367 