### PR TITLE
Tighten up light-scheme colors

### DIFF
--- a/Sources/Secretive/Views/CopyableView.swift
+++ b/Sources/Secretive/Views/CopyableView.swift
@@ -80,9 +80,9 @@ struct CopyableView: View {
     var backgroundColor: Color {
         switch interactionState {
         case .normal:
-            return colorScheme == .dark ? Color(white: 0.2) : Color(white: 0.85)
+            return colorScheme == .dark ? Color(white: 0.2) : Color(white: 0.885)
         case .hovering:
-            return colorScheme == .dark ? Color(white: 0.275) : Color(white: 0.75)
+            return colorScheme == .dark ? Color(white: 0.275) : Color(white: 0.8)
         case .clicking:
             return .accentColor
         }

--- a/Sources/Secretive/Views/CopyableView.swift
+++ b/Sources/Secretive/Views/CopyableView.swift
@@ -82,7 +82,7 @@ struct CopyableView: View {
         case .normal:
             return colorScheme == .dark ? Color(white: 0.2) : Color(white: 0.885)
         case .hovering:
-            return colorScheme == .dark ? Color(white: 0.275) : Color(white: 0.8)
+            return colorScheme == .dark ? Color(white: 0.275) : Color(white: 0.82)
         case .clicking:
             return .accentColor
         }

--- a/Sources/Secretive/Views/CopyableView.swift
+++ b/Sources/Secretive/Views/CopyableView.swift
@@ -8,6 +8,7 @@ struct CopyableView: View {
     var text: String
 
     @State private var interactionState: InteractionState = .normal
+    @Environment(\.colorScheme) private var colorScheme
 
     var body: some View {
         VStack(alignment: .leading) {
@@ -77,38 +78,32 @@ struct CopyableView: View {
     }
 
     var backgroundColor: Color {
-        let color: NSColor
         switch interactionState {
         case .normal:
-            color = .windowBackgroundColor
+            return colorScheme == .dark ? Color(white: 0.2) : Color(white: 0.85)
         case .hovering:
-            color = .unemphasizedSelectedContentBackgroundColor
+            return colorScheme == .dark ? Color(white: 0.275) : Color(white: 0.75)
         case .clicking:
-            color = .selectedContentBackgroundColor
+            return .accentColor
         }
-        return Color(color)
     }
 
     var primaryTextColor: Color {
-        let color: NSColor
         switch interactionState {
         case .normal, .hovering:
-            color = .textColor
+            return Color(.textColor)
         case .clicking:
-            color = .white
+            return .white
         }
-        return Color(color)
     }
 
     var secondaryTextColor: Color {
-        let color: NSColor
         switch interactionState {
         case .normal, .hovering:
-            color = .secondaryLabelColor
+            return Color(.secondaryLabelColor)
         case .clicking:
-            color = .white
+            return .white
         }
-        return Color(color)
     }
 
     func copy() {
@@ -128,7 +123,9 @@ struct CopyableView_Previews: PreviewProvider {
     static var previews: some View {
         Group {
             CopyableView(title: "Title", image: Image(systemName: "figure.wave"), text: "Hello world.")
+                .padding()
             CopyableView(title: "Title", image: Image(systemName: "figure.wave"), text: "Long text. Long text. Long text. Long text. Long text. Long text. Long text. Long text. Long text. Long text. Long text. Long text. Long text. Long text. Long text. Long text. Long text. Long text. Long text. Long text. Long text. Long text. Long text. Long text. Long text. Long text. Long text. Long text. Long text. ")
+                .padding()
         }
     }
 }


### PR DESCRIPTION
Before: 
<img width="1141" alt="Screenshot 2022-12-18 at 3 06 28 PM" src="https://user-images.githubusercontent.com/342665/208324137-86aa8a46-0720-4296-927f-c1c401958b86.png">

After:
<img width="1141" alt="Screenshot 2022-12-18 at 3 09 54 PM" src="https://user-images.githubusercontent.com/342665/208324276-2e701720-0099-4e2d-9148-4272b0846e70.png">


Fixes #428 