### PR TITLE
Rounded out the rest of the SmartCardStore API

### DIFF
--- a/Sources/Packages/Sources/SecretKit/Erasers/AnySecretStore.swift
+++ b/Sources/Packages/Sources/SecretKit/Erasers/AnySecretStore.swift
@@ -10,6 +10,7 @@ public class AnySecretStore: SecretStore {
     private let _name: () -> String
     private let _secrets: () -> [AnySecret]
     private let _sign: (Data, AnySecret, SigningRequestProvenance) throws -> Data
+    private let _verify: (Data, Data, AnySecret) throws -> Bool
     private let _existingPersistedAuthenticationContext: (AnySecret) -> PersistedAuthenticationContext?
     private let _persistAuthentication: (AnySecret, TimeInterval) throws -> Void
     private let _reloadSecrets: () -> Void
@@ -23,6 +24,7 @@ public class AnySecretStore: SecretStore {
         _id = { secretStore.id }
         _secrets = { secretStore.secrets.map { AnySecret($0) } }
         _sign = { try secretStore.sign(data: $0, with: $1.base as! SecretStoreType.SecretType, for: $2) }
+        _verify = { try secretStore.verify(data: $0, signature: $1, with: $2.base as! SecretStoreType.SecretType) }
         _existingPersistedAuthenticationContext = { secretStore.existingPersistedAuthenticationContext(secret: $0.base as! SecretStoreType.SecretType) }
         _persistAuthentication = { try secretStore.persistAuthentication(secret: $0.base as! SecretStoreType.SecretType, forDuration: $1) }
         _reloadSecrets = { secretStore.reloadSecrets() }
@@ -49,6 +51,10 @@ public class AnySecretStore: SecretStore {
 
     public func sign(data: Data, with secret: AnySecret, for provenance: SigningRequestProvenance) throws -> Data {
         try _sign(data, secret, provenance)
+    }
+
+    public func verify(data: Data, signature: Data, with secret: AnySecret) throws -> Bool {
+        try _verify(data, signature, secret)
     }
 
     public func existingPersistedAuthenticationContext(secret: AnySecret) -> PersistedAuthenticationContext? {

--- a/Sources/Packages/Sources/SecretKit/Erasers/AnySecretStore.swift
+++ b/Sources/Packages/Sources/SecretKit/Erasers/AnySecretStore.swift
@@ -24,7 +24,7 @@ public class AnySecretStore: SecretStore {
         _id = { secretStore.id }
         _secrets = { secretStore.secrets.map { AnySecret($0) } }
         _sign = { try secretStore.sign(data: $0, with: $1.base as! SecretStoreType.SecretType, for: $2) }
-        _verify = { try secretStore.verify(data: $0, signature: $1, with: $2.base as! SecretStoreType.SecretType) }
+        _verify = { try secretStore.verify(signature: $0, for: $1, with: $2.base as! SecretStoreType.SecretType) }
         _existingPersistedAuthenticationContext = { secretStore.existingPersistedAuthenticationContext(secret: $0.base as! SecretStoreType.SecretType) }
         _persistAuthentication = { try secretStore.persistAuthentication(secret: $0.base as! SecretStoreType.SecretType, forDuration: $1) }
         _reloadSecrets = { secretStore.reloadSecrets() }
@@ -53,8 +53,8 @@ public class AnySecretStore: SecretStore {
         try _sign(data, secret, provenance)
     }
 
-    public func verify(data: Data, signature: Data, with secret: AnySecret) throws -> Bool {
-        try _verify(data, signature, secret)
+    public func verify(signature: Data, for data: Data, with secret: AnySecret) throws -> Bool {
+        try _verify(signature, data, secret)
     }
 
     public func existingPersistedAuthenticationContext(secret: AnySecret) -> PersistedAuthenticationContext? {

--- a/Sources/Packages/Sources/SecretKit/OpenSSH/OpenSSHKeyWriter.swift
+++ b/Sources/Packages/Sources/SecretKit/OpenSSH/OpenSSHKeyWriter.swift
@@ -65,6 +65,8 @@ extension OpenSSHKeyWriter {
         case .ellipticCurve:
             return "ecdsa-sha2-nistp" + String(describing: length)
         case .rsa:
+            // All RSA keys use the same 512 bit hash function, per
+            // https://security.stackexchange.com/questions/255074/why-are-rsa-sha2-512-and-rsa-sha2-256-supported-but-not-reported-by-ssh-q-key
             return "rsa-sha2-512"
         }
     }
@@ -79,6 +81,7 @@ extension OpenSSHKeyWriter {
         case .ellipticCurve:
             return "nistp" + String(describing: length)
         case .rsa:
+            // All RSA keys use the same 512 bit hash function
             return "rsa-sha2-512"
         }
     }

--- a/Sources/Packages/Sources/SecretKit/OpenSSH/OpenSSHKeyWriter.swift
+++ b/Sources/Packages/Sources/SecretKit/OpenSSH/OpenSSHKeyWriter.swift
@@ -64,6 +64,8 @@ extension OpenSSHKeyWriter {
         switch algorithm {
         case .ellipticCurve:
             return "ecdsa-sha2-nistp" + String(describing: length)
+        case .rsa:
+            return "rsa-sha2-512"
         }
     }
 
@@ -76,6 +78,8 @@ extension OpenSSHKeyWriter {
         switch algorithm {
         case .ellipticCurve:
             return "nistp" + String(describing: length)
+        case .rsa:
+            return "rsa-sha2-512"
         }
     }
 

--- a/Sources/Packages/Sources/SecretKit/Types/Secret.swift
+++ b/Sources/Packages/Sources/SecretKit/Types/Secret.swift
@@ -20,6 +20,7 @@ public protocol Secret: Identifiable, Hashable {
 public enum Algorithm: Hashable {
 
     case ellipticCurve
+    case rsa
 
     /// Initializes the Algorithm with a secAttr representation of an algorithm.
     /// - Parameter secAttr: the secAttr, represented as an NSNumber.
@@ -28,8 +29,19 @@ public enum Algorithm: Hashable {
         switch secAttrString {
         case kSecAttrKeyTypeEC:
             self = .ellipticCurve
+        case kSecAttrKeyTypeRSA:
+            self = .rsa
         default:
             fatalError()
+        }
+    }
+    
+    public var secAttrKeyType: CFString {
+        switch self {
+        case .ellipticCurve:
+            return kSecAttrKeyTypeEC
+        case .rsa:
+            return kSecAttrKeyTypeRSA
         }
     }
 }

--- a/Sources/Packages/Sources/SecretKit/Types/SecretStore.swift
+++ b/Sources/Packages/Sources/SecretKit/Types/SecretStore.swift
@@ -79,3 +79,15 @@ extension NSNotification.Name {
     public static let secretStoreReloaded = NSNotification.Name("com.maxgoedjen.Secretive.secretStore.reloaded")
 
 }
+
+public typealias SecurityError = Unmanaged<CFError>
+
+extension CFError {
+
+    public static let verifyError = CFErrorCreate(nil, NSOSStatusErrorDomain as CFErrorDomain, CFIndex(errSecVerifyFailed), nil)!
+
+    static public func ~=(lhs: CFError, rhs: CFError) -> Bool {
+        CFErrorGetDomain(lhs) == CFErrorGetDomain(rhs) && CFErrorGetCode(lhs) == CFErrorGetCode(rhs)
+    }
+
+}

--- a/Sources/Packages/Sources/SecretKit/Types/SecretStore.swift
+++ b/Sources/Packages/Sources/SecretKit/Types/SecretStore.swift
@@ -23,6 +23,14 @@ public protocol SecretStore: ObservableObject, Identifiable {
     /// - Returns: The signed data.
     func sign(data: Data, with secret: SecretType, for provenance: SigningRequestProvenance) throws -> Data
 
+    /// Verifies that a signature is valid over a specified payload.
+    /// - Parameters:
+    ///   - data: The data to verify the signature of.
+    ///   - signature: The signature over the data.
+    ///   - secret: The secret whose signature to verify.
+    /// - Returns: Whether the signature was verified.
+    func verify(data: Data, signature: Data, with secret: SecretType) throws -> Bool
+
     /// Checks to see if there is currently a valid persisted authentication for a given secret.
     /// - Parameters:
     ///   - secret: The ``Secret`` to check if there is a persisted authentication for.

--- a/Sources/Packages/Sources/SecretKit/Types/SecretStore.swift
+++ b/Sources/Packages/Sources/SecretKit/Types/SecretStore.swift
@@ -25,11 +25,11 @@ public protocol SecretStore: ObservableObject, Identifiable {
 
     /// Verifies that a signature is valid over a specified payload.
     /// - Parameters:
-    ///   - data: The data to verify the signature of.
     ///   - signature: The signature over the data.
+    ///   - data: The data to verify the signature of.
     ///   - secret: The secret whose signature to verify.
     /// - Returns: Whether the signature was verified.
-    func verify(data: Data, signature: Data, with secret: SecretType) throws -> Bool
+    func verify(signature: Data, for data: Data, with secret: SecretType) throws -> Bool
 
     /// Checks to see if there is currently a valid persisted authentication for a given secret.
     /// - Parameters:

--- a/Sources/Packages/Sources/SecureEnclaveSecretKit/SecureEnclaveStore.swift
+++ b/Sources/Packages/Sources/SecureEnclaveSecretKit/SecureEnclaveStore.swift
@@ -162,11 +162,11 @@ extension SecureEnclave {
                 throw KeychainError(statusCode: errSecSuccess)
             }
             let key = untypedSafe as! SecKey
-            let signature = SecKeyVerifySignature(key, .ecdsaSignatureMessageX962SHA256, data as CFData, signature as CFData, &verifyError)
-            if !signature {
+            let verified = SecKeyVerifySignature(key, .ecdsaSignatureMessageX962SHA256, data as CFData, signature as CFData, &verifyError)
+            if !verified, let verifyError {
                 throw SigningError(error: verifyError)
             }
-            return signature
+            return verified
         }
 
         public func existingPersistedAuthenticationContext(secret: Secret) -> PersistedAuthenticationContext? {

--- a/Sources/Packages/Sources/SecureEnclaveSecretKit/SecureEnclaveStore.swift
+++ b/Sources/Packages/Sources/SecureEnclaveSecretKit/SecureEnclaveStore.swift
@@ -164,7 +164,11 @@ extension SecureEnclave {
             let key = untypedSafe as! SecKey
             let verified = SecKeyVerifySignature(key, .ecdsaSignatureMessageX962SHA256, data as CFData, signature as CFData, &verifyError)
             if !verified, let verifyError {
-                throw SigningError(error: verifyError)
+                if verifyError.takeUnretainedValue() ~= .verifyError {
+                    return false
+                } else {
+                    throw SigningError(error: verifyError)
+                }
             }
             return verified
         }
@@ -313,11 +317,6 @@ extension SecureEnclave {
 
 }
 
-extension SecureEnclave {
-
-    public typealias SecurityError = Unmanaged<CFError>
-
-}
 
 extension SecureEnclave {
 

--- a/Sources/Packages/Sources/SecureEnclaveSecretKit/SecureEnclaveStore.swift
+++ b/Sources/Packages/Sources/SecureEnclaveSecretKit/SecureEnclaveStore.swift
@@ -138,7 +138,7 @@ extension SecureEnclave {
             return signature as Data
         }
 
-        public func verify(data: Data, signature: Data, with secret: Secret) throws -> Bool {
+        public func verify(signature: Data, for data: Data, with secret: Secret) throws -> Bool {
             let context = LAContext()
             context.localizedReason = "verify a signature using secret \"\(secret.name)\""
             context.localizedCancelTitle = "Deny"

--- a/Sources/Packages/Sources/SmartCardSecretKit/SmartCardStore.swift
+++ b/Sources/Packages/Sources/SmartCardSecretKit/SmartCardStore.swift
@@ -45,7 +45,7 @@ extension SmartCard {
             fatalError("Keys must be deleted on the smart card.")
         }
 
-        public func sign(data: Data, with secret: SecretType, for provenance: SigningRequestProvenance) throws -> Data {
+        public func sign(data: Data, with secret: Secret, for provenance: SigningRequestProvenance) throws -> Data {
             guard let tokenID = tokenID else { fatalError() }
             let context = LAContext()
             context.localizedReason = "sign a request from \"\(provenance.origin.displayName)\" using secret \"\(secret.name)\""
@@ -86,16 +86,14 @@ extension SmartCard {
             }
             return signature as Data
         }
-        
-        public func verify(data: Data, signature: Data, with secret: SecretType) throws -> Bool {
-        
+        public func verify(data: Data, signature: Data, with secret: Secret) throws -> Bool {
             let attributes = KeychainDictionary([
                 kSecAttrKeyType: secret.algorithm.secAttrKeyType,
                 kSecAttrKeySizeInBits: secret.keySize,
                 kSecAttrKeyClass: kSecAttrKeyClassPublic
             ])
-            var encryptError: SecurityError?
-            var untyped: CFTypeRef? = SecKeyCreateWithData(secret.publicKey as CFData, attributes, &encryptError)
+            var verifyError: SecurityError?
+            let untyped: CFTypeRef? = SecKeyCreateWithData(secret.publicKey as CFData, attributes, &verifyError)
             guard let untypedSafe = untyped else {
                 throw KeychainError(statusCode: errSecSuccess)
             }
@@ -113,84 +111,11 @@ extension SmartCard {
             default:
                 fatalError()
             }
-            let signature = SecKeyVerifySignature(key, signatureAlgorithm, data as CFData, signature as CFData, &encryptError)
+            let signature = SecKeyVerifySignature(key, signatureAlgorithm, data as CFData, signature as CFData, &verifyError)
             if !signature {
-                throw SigningError(error: encryptError)
+                throw SigningError(error: verifyError)
             }
             return signature
-        }
-        
-        public func encrypt(data: Data, with secret: SecretType) throws -> Data {
-            let attributes = KeychainDictionary([
-                kSecAttrKeyType: secret.algorithm.secAttrKeyType,
-                kSecAttrKeySizeInBits: secret.keySize,
-                kSecAttrKeyClass: kSecAttrKeyClassPublic
-            ])
-            var encryptError: SecurityError?
-            let untyped: CFTypeRef? = SecKeyCreateWithData(secret.publicKey as CFData, attributes, &encryptError)
-            guard let untypedSafe = untyped else {
-                throw KeychainError(statusCode: errSecSuccess)
-            }
-            let key = untypedSafe as! SecKey
-            let signatureAlgorithm: SecKeyAlgorithm
-            switch (secret.algorithm, secret.keySize) {
-            case (.ellipticCurve, 256):
-                signatureAlgorithm = .eciesEncryptionCofactorVariableIVX963SHA256AESGCM
-            case (.ellipticCurve, 384):
-                signatureAlgorithm = .eciesEncryptionCofactorVariableIVX963SHA256AESGCM
-            case (.rsa, 1024):
-                signatureAlgorithm = .rsaEncryptionOAEPSHA512AESGCM
-            case (.rsa, 2048):
-                signatureAlgorithm = .rsaEncryptionOAEPSHA512AESGCM
-            default:
-                fatalError()
-            }
-            guard let signature = SecKeyCreateEncryptedData(key, signatureAlgorithm, data as CFData, &encryptError) else {
-                throw SigningError(error: encryptError)
-            }
-            return signature as Data
-        }
-        
-        public func decrypt(data: Data, with secret: SecretType) throws -> Data {
-            guard let tokenID = tokenID else { fatalError() }
-            let context = LAContext()
-            context.localizedReason = "decrypt a file using secret \"\(secret.name)\""
-            context.localizedCancelTitle = "Deny"
-            let attributes = KeychainDictionary([
-                kSecClass: kSecClassKey,
-                kSecAttrKeyClass: kSecAttrKeyClassPrivate,
-                kSecAttrApplicationLabel: secret.id as CFData,
-                kSecAttrTokenID: tokenID,
-                kSecUseAuthenticationContext: context,
-                kSecReturnRef: true
-            ])
-            var untyped: CFTypeRef?
-            let status = SecItemCopyMatching(attributes, &untyped)
-            if status != errSecSuccess {
-                throw KeychainError(statusCode: status)
-            }
-            guard let untypedSafe = untyped else {
-                throw KeychainError(statusCode: errSecSuccess)
-            }
-            let key = untypedSafe as! SecKey
-            var encryptError: SecurityError?
-            let signatureAlgorithm: SecKeyAlgorithm
-            switch (secret.algorithm, secret.keySize) {
-            case (.ellipticCurve, 256):
-                signatureAlgorithm = .eciesEncryptionStandardX963SHA256AESGCM
-            case (.ellipticCurve, 384):
-                signatureAlgorithm = .eciesEncryptionStandardX963SHA384AESGCM
-            case (.rsa, 1024):
-                signatureAlgorithm = .rsaEncryptionOAEPSHA512AESGCM
-            case (.rsa, 2048):
-                signatureAlgorithm = .rsaEncryptionOAEPSHA512AESGCM
-            default:
-                fatalError()
-            }
-            guard let signature = SecKeyCreateDecryptedData(key, signatureAlgorithm, data as CFData, &encryptError) else {
-                throw SigningError(error: encryptError)
-            }
-            return signature as Data
         }
 
         public func existingPersistedAuthenticationContext(secret: SmartCard.Secret) -> PersistedAuthenticationContext? {
@@ -269,6 +194,99 @@ extension SmartCard.Store {
             return SmartCard.Secret(id: tokenID, name: name, algorithm: algorithm, keySize: keySize, publicKey: publicKey)
         }
         secrets.append(contentsOf: wrapped)
+    }
+
+}
+
+
+// MARK: Smart Card specific encryption/decryption/verification
+extension SmartCard.Store {
+
+    /// Encrypts a payload with a specified key.
+    /// - Parameters:
+    ///   - data: The payload to encrypt.
+    ///   - secret: The secret to encrypt with.
+    /// - Returns: The encrypted data.
+    /// - Warning: Encryption functions are deliberately only exposed on a library level, and are not exposed in Secretive itself to prevent users from data loss. Any pull requests which expose this functionality in the app will not be merged.
+    public func encrypt(data: Data, with secret: SecretType) throws -> Data {
+        let context = LAContext()
+        context.localizedReason = "encrypt data using secret \"\(secret.name)\""
+        context.localizedCancelTitle = "Deny"
+        let attributes = KeychainDictionary([
+            kSecAttrKeyType: secret.algorithm.secAttrKeyType,
+            kSecAttrKeySizeInBits: secret.keySize,
+            kSecAttrKeyClass: kSecAttrKeyClassPublic,
+            kSecUseAuthenticationContext: context
+        ])
+        var encryptError: SmartCard.SecurityError?
+        let untyped: CFTypeRef? = SecKeyCreateWithData(secret.publicKey as CFData, attributes, &encryptError)
+        guard let untypedSafe = untyped else {
+            throw SmartCard.KeychainError(statusCode: errSecSuccess)
+        }
+        let key = untypedSafe as! SecKey
+        let signatureAlgorithm: SecKeyAlgorithm
+        switch (secret.algorithm, secret.keySize) {
+        case (.ellipticCurve, 256):
+            signatureAlgorithm = .eciesEncryptionCofactorVariableIVX963SHA256AESGCM
+        case (.ellipticCurve, 384):
+            signatureAlgorithm = .eciesEncryptionCofactorVariableIVX963SHA256AESGCM
+        case (.rsa, 1024):
+            signatureAlgorithm = .rsaEncryptionOAEPSHA512AESGCM
+        case (.rsa, 2048):
+            signatureAlgorithm = .rsaEncryptionOAEPSHA512AESGCM
+        default:
+            fatalError()
+        }
+        guard let signature = SecKeyCreateEncryptedData(key, signatureAlgorithm, data as CFData, &encryptError) else {
+            throw SmartCard.SigningError(error: encryptError)
+        }
+        return signature as Data
+    }
+
+    /// Decrypts a payload with a specified key.
+    /// - Parameters:
+    ///   - data: The payload to decrypt.
+    ///   - secret: The secret to decrypt with.
+    /// - Returns: The decrypted data.
+    /// - Warning: Encryption functions are deliberately only exposed on a library level, and are not exposed in Secretive itself to prevent users from data loss. Any pull requests which expose this functionality in the app will not be merged.
+    public func decrypt(data: Data, with secret: SecretType) throws -> Data {
+        guard let tokenID = tokenID else { fatalError() }
+        let context = LAContext()
+        context.localizedReason = "decrypt data using secret \"\(secret.name)\""
+        context.localizedCancelTitle = "Deny"
+        let attributes = KeychainDictionary([
+            kSecClass: kSecClassKey,
+            kSecAttrKeyClass: kSecAttrKeyClassPrivate,
+            kSecAttrApplicationLabel: secret.id as CFData,
+            kSecAttrTokenID: tokenID,
+            kSecUseAuthenticationContext: context,
+            kSecReturnRef: true
+        ])
+        var untyped: CFTypeRef?
+        let status = SecItemCopyMatching(attributes, &untyped)
+        if status != errSecSuccess {
+            throw SmartCard.KeychainError(statusCode: status)
+        }
+        guard let untypedSafe = untyped else {
+            throw SmartCard.KeychainError(statusCode: errSecSuccess)
+        }
+        let key = untypedSafe as! SecKey
+        var encryptError: SmartCard.SecurityError?
+        let signatureAlgorithm: SecKeyAlgorithm
+        switch (secret.algorithm, secret.keySize) {
+        case (.ellipticCurve, 256):
+            signatureAlgorithm = .eciesEncryptionStandardX963SHA256AESGCM
+        case (.ellipticCurve, 384):
+            signatureAlgorithm = .eciesEncryptionStandardX963SHA384AESGCM
+        case (.rsa, 1024), (.rsa, 2048):
+            signatureAlgorithm = .rsaEncryptionOAEPSHA512AESGCM
+        default:
+            fatalError()
+        }
+        guard let signature = SecKeyCreateDecryptedData(key, signatureAlgorithm, data as CFData, &encryptError) else {
+            throw SmartCard.SigningError(error: encryptError)
+        }
+        return signature as Data
     }
 
 }

--- a/Sources/Packages/Sources/SmartCardSecretKit/SmartCardStore.swift
+++ b/Sources/Packages/Sources/SmartCardSecretKit/SmartCardStore.swift
@@ -111,11 +111,11 @@ extension SmartCard {
             default:
                 fatalError()
             }
-            let signature = SecKeyVerifySignature(key, signatureAlgorithm, data as CFData, signature as CFData, &verifyError)
-            if !signature {
+            let verified = SecKeyVerifySignature(key, signatureAlgorithm, data as CFData, signature as CFData, &verifyError)
+            if !verified, let verifyError {
                 throw SigningError(error: verifyError)
             }
-            return signature
+            return verified
         }
 
         public func existingPersistedAuthenticationContext(secret: SmartCard.Secret) -> PersistedAuthenticationContext? {

--- a/Sources/Packages/Sources/SmartCardSecretKit/SmartCardStore.swift
+++ b/Sources/Packages/Sources/SmartCardSecretKit/SmartCardStore.swift
@@ -86,7 +86,7 @@ extension SmartCard {
             }
             return signature as Data
         }
-        public func verify(data: Data, signature: Data, with secret: Secret) throws -> Bool {
+        public func verify(signature: Data, for data: Data, with secret: Secret) throws -> Bool {
             let attributes = KeychainDictionary([
                 kSecAttrKeyType: secret.algorithm.secAttrKeyType,
                 kSecAttrKeySizeInBits: secret.keySize,

--- a/Sources/Packages/Tests/SecretAgentKitTests/AgentTests.swift
+++ b/Sources/Packages/Tests/SecretAgentKitTests/AgentTests.swift
@@ -61,8 +61,13 @@ class AgentTests: XCTestCase {
         var rs = r
         rs.append(s)
         let signature = try! P256.Signing.ECDSASignature(rawRepresentation: rs)
-        let valid = try! P256.Signing.PublicKey(x963Representation: Constants.Secrets.ecdsa256Secret.publicKey).isValidSignature(signature, for: dataToSign)
-        XCTAssertTrue(valid)
+        let refereneceValid = try! P256.Signing.PublicKey(x963Representation: Constants.Secrets.ecdsa256Secret.publicKey).isValidSignature(signature, for: dataToSign)
+        let store = list.stores.first!
+        let valid = try? store.verify(signature: rs, for: dataToSign, with: AnySecret(Constants.Secrets.ecdsa256Secret))
+        let invalid = try? store.verify(signature: rs, for: dataToSign, with: AnySecret(Constants.Secrets.ecdsa256Secret))
+        XCTAssertTrue(refereneceValid)
+        XCTAssert(valid == true)
+        XCTAssert(invalid == false)
     }
 
     // MARK: Witness protocol

--- a/Sources/Packages/Tests/SecretAgentKitTests/AgentTests.swift
+++ b/Sources/Packages/Tests/SecretAgentKitTests/AgentTests.swift
@@ -61,13 +61,17 @@ class AgentTests: XCTestCase {
         var rs = r
         rs.append(s)
         let signature = try! P256.Signing.ECDSASignature(rawRepresentation: rs)
-        let refereneceValid = try! P256.Signing.PublicKey(x963Representation: Constants.Secrets.ecdsa256Secret.publicKey).isValidSignature(signature, for: dataToSign)
+        let referenceValid = try! P256.Signing.PublicKey(x963Representation: Constants.Secrets.ecdsa256Secret.publicKey).isValidSignature(signature, for: dataToSign)
         let store = list.stores.first!
-        let valid = try? store.verify(signature: rs, for: dataToSign, with: AnySecret(Constants.Secrets.ecdsa256Secret))
-        let invalid = try? store.verify(signature: rs, for: dataToSign, with: AnySecret(Constants.Secrets.ecdsa256Secret))
-        XCTAssertTrue(refereneceValid)
-        XCTAssert(valid == true)
-        XCTAssert(invalid == false)
+        let derVerifies = try! store.verify(signature: signature.derRepresentation, for: dataToSign, with: AnySecret(Constants.Secrets.ecdsa256Secret))
+        let invalidRandomSignature = try? store.verify(signature: "invalid".data(using: .utf8)!, for: dataToSign, with: AnySecret(Constants.Secrets.ecdsa256Secret))
+        let invalidRandomData = try? store.verify(signature: signature.derRepresentation, for: "invalid".data(using: .utf8)!, with: AnySecret(Constants.Secrets.ecdsa256Secret))
+        let invalidWrongKey = try? store.verify(signature: signature.derRepresentation, for: dataToSign, with: AnySecret(Constants.Secrets.ecdsa384Secret))
+        XCTAssertTrue(referenceValid)
+        XCTAssertTrue(derVerifies)
+        XCTAssert(invalidRandomSignature == false)
+        XCTAssert(invalidRandomData == false)
+        XCTAssert(invalidWrongKey == false)
     }
 
     // MARK: Witness protocol

--- a/Sources/Packages/Tests/SecretAgentKitTests/StubStore.swift
+++ b/Sources/Packages/Tests/SecretAgentKitTests/StubStore.swift
@@ -70,7 +70,7 @@ extension Stub {
             return SecKeyCreateSignature(privateKey, signatureAlgorithm, data as CFData, nil)! as Data
         }
 
-        public func verify(data: Data, signature: Data, with secret: Stub.Secret) throws -> Bool {
+        public func verify(signature: Data, for data: Data, with secret: Stub.Secret) throws -> Bool {
             let attributes = KeychainDictionary([
                 kSecAttrKeyType: secret.algorithm.secAttrKeyType,
                 kSecAttrKeySizeInBits: secret.keySize,

--- a/Sources/Packages/Tests/SecretAgentKitTests/StubStore.swift
+++ b/Sources/Packages/Tests/SecretAgentKitTests/StubStore.swift
@@ -70,6 +70,39 @@ extension Stub {
             return SecKeyCreateSignature(privateKey, signatureAlgorithm, data as CFData, nil)! as Data
         }
 
+        public func verify(data: Data, signature: Data, with secret: Stub.Secret) throws -> Bool {
+            let attributes = KeychainDictionary([
+                kSecAttrKeyType: secret.algorithm.secAttrKeyType,
+                kSecAttrKeySizeInBits: secret.keySize,
+                kSecAttrKeyClass: kSecAttrKeyClassPublic
+            ])
+            var verifyError: Unmanaged<CFError>?
+            let untyped: CFTypeRef? = SecKeyCreateWithData(secret.publicKey as CFData, attributes, &verifyError)
+            guard let untypedSafe = untyped else {
+                throw NSError(domain: "test", code: 0, userInfo: nil)
+            }
+            let key = untypedSafe as! SecKey
+            let signatureAlgorithm: SecKeyAlgorithm
+            switch (secret.algorithm, secret.keySize) {
+            case (.ellipticCurve, 256):
+                signatureAlgorithm = .ecdsaSignatureMessageX962SHA256
+            case (.ellipticCurve, 384):
+                signatureAlgorithm = .ecdsaSignatureMessageX962SHA384
+            case (.rsa, 1024):
+                signatureAlgorithm = .rsaSignatureMessagePKCS1v15SHA512
+            case (.rsa, 2048):
+                signatureAlgorithm = .rsaSignatureMessagePKCS1v15SHA512
+            default:
+                fatalError()
+            }
+            let verified = SecKeyVerifySignature(key, signatureAlgorithm, data as CFData, signature as CFData, &verifyError)
+            if verifyError != nil {
+                print(verifyError!.takeUnretainedValue())
+                throw NSError(domain: "test", code: 0, userInfo: nil)
+            }
+            return verified
+        }
+
         public func existingPersistedAuthenticationContext(secret: Stub.Secret) -> PersistedAuthenticationContext? {
             nil
         }

--- a/Sources/Packages/Tests/SecretAgentKitTests/StubStore.swift
+++ b/Sources/Packages/Tests/SecretAgentKitTests/StubStore.swift
@@ -96,9 +96,12 @@ extension Stub {
                 fatalError()
             }
             let verified = SecKeyVerifySignature(key, signatureAlgorithm, data as CFData, signature as CFData, &verifyError)
-            if verifyError != nil {
-                print(verifyError!.takeUnretainedValue())
-                throw NSError(domain: "test", code: 0, userInfo: nil)
+            if let verifyError {
+                if verifyError.takeUnretainedValue() ~= .verifyError {
+                    return false
+                } else {
+                    throw NSError(domain: "test", code: 0, userInfo: nil)
+                }
             }
             return verified
         }

--- a/Sources/Secretive/Preview Content/PreviewStore.swift
+++ b/Sources/Secretive/Preview Content/PreviewStore.swift
@@ -40,6 +40,10 @@ extension Preview {
             return data
         }
 
+        func verify(data: Data, signature: Data, with secret: Preview.Secret) throws -> Bool {
+            true
+        }
+
         func existingPersistedAuthenticationContext(secret: Preview.Secret) -> PersistedAuthenticationContext? {
             nil
         }

--- a/Sources/Secretive/Views/EmptyStoreView.swift
+++ b/Sources/Secretive/Views/EmptyStoreView.swift
@@ -34,7 +34,7 @@ struct EmptyStoreImmutableView: View {
         VStack {
             Text("No Secrets").bold()
             Text("Use your Smart Card's management tool to create a secret.")
-            Text("Secretive only supports Elliptic Curve keys.")
+            Text("Secretive supports EC256, EC384, RSA1024, and RSA2048 keys.")
         }.frame(maxWidth: .infinity, maxHeight: .infinity)
     }
     


### PR DESCRIPTION
I'm not sure who this is for, and I'm only 80% sure the openssh identifiers are correct, but you can do this, and you probably could support RSA keys on smart cards.

I could also probably move the verify and encrypt API up a few levels because it only needs a public key. 

Also, for completeness, the OpenSSH API should have a way to load the public keys.