### PR TITLE
Fix bug where public keys directory would not be created

### DIFF
--- a/Sources/Packages/Sources/SecretKit/PublicKeyStandinFileController.swift
+++ b/Sources/Packages/Sources/SecretKit/PublicKeyStandinFileController.swift
@@ -20,8 +20,10 @@ public class PublicKeyFileStoreController {
         logger.log("Writing public keys to disk")
         if clear {
             let validPaths = Set(secrets.map { publicKeyPath(for: $0) }).union(Set(secrets.map { sshCertificatePath(for: $0) }))
-            let untracked = Set(try FileManager.default.contentsOfDirectory(atPath: directory)
-                .map { "\(directory)/\($0)" })
+            let contentsOfDirectory = (try? FileManager.default.contentsOfDirectory(atPath: directory)) ?? []
+            let fullPathContents = contentsOfDirectory.map { "\(directory)/\($0)" }
+
+            let untracked = Set(fullPathContents)
                 .subtracting(validPaths)
             for path in untracked {
                 try? FileManager.default.removeItem(at: URL(fileURLWithPath: path))


### PR DESCRIPTION
The `try` on https://github.com/maxgoedjen/secretive/pull/476/files#diff-e73a4260fbc17590be26464100542cebbd891e5f21b5b068c275430d4ed6bb60L23 would throw if the directory had not yet been created, preventing the intended creation below.

Fixes #475