### PR TITLE
Fix escaped text on Agent is running popover

### DIFF
--- a/Sources/Secretive/Localizable.xcstrings
+++ b/Sources/Secretive/Localizable.xcstrings
@@ -22,7 +22,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "SecretAgent is a process that runs in the background to sign requests, so you don't need to keep Secretive open all the time.\\n\\n**You can close Secretive, and everything will still keep working.**"
+            "value" : "SecretAgent is a process that runs in the background to sign requests, so you don't need to keep Secretive open all the time.\n\n**You can close Secretive, and everything will still keep working.**"
           }
         }
       }


### PR DESCRIPTION
This PR fixes the unintended display of `\n\n` in the "Agent is Running" popover:

<img width="386" alt="SCR-20240108-hgxd" src="https://github.com/maxgoedjen/secretive/assets/3832/aca09a16-2ea8-4cbf-b6e3-a49a6a483b86">
