### PR TITLE
GitHub Actions updates

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -10,7 +10,7 @@ jobs:
     name: Add issue to project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@v0.0.3
+      - uses: actions/add-to-project@v1.0.1
         with:
           project-url: https://github.com/users/maxgoedjen/projects/1
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -48,7 +48,7 @@ jobs:
             shasum -a 256 Secretive.zip
             shasum -a 256 Archive.zip
     - name: Upload App to Artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: Secretive.zip
         path: Secretive.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,12 +107,12 @@ jobs:
         asset_name: Secretive.zip
         asset_content_type: application/zip
     - name: Upload App to Artifacts
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       with:
         name: Secretive.zip
         path: Secretive.zip
     - name: Upload Archive to Artifacts
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       with:
         name: Xcode_Archive.zip
         path: Archive.zip


### PR DESCRIPTION
## Description

This PR updates some of this project's workflows to use newer versions of official reusable actions:

- [actions/add-to-project](https://github.com/actions/add-to-project) is updated to v1.0.1
- [actions/upload-artifact](https://github.com/actions/upload-artifact) is updated to v4

In both cases, the updates _should_ address deprecation notices on the changed workflows.

## Future Considerations

There are a few things I opted not to do as part of this PR:

**Fixing formatting and indentation in workflow YML files.** I ignored this for now as it would introduce a much larger diff and would obscure the meaningful changes.

**Migrating from archived actions to maintained replacements.** In 2021, GitHub archived two of the actions used by this project:

- [actions/create-release](https://github.com/actions/create-release)
- [actions/upload-release-asset](https://github.com/actions/upload-release-asset)

That's rather bothersome. Both of those actions are generating deprecation warnings and _could_ stop working at some point in the future altogether.

Some ideas:

1. Transition the "release" workflow to trigger on the creation of a Release rather than on tag creation. This may be done either via the web UI or the CLI (e.g. `gh release create v1.2.3 --generate-notes`). Creating a Release will generate a tag and I _think_ much of the existing "release" workflow can remain the same. That is a process change, though.

2. Replace the use of actions/upload-release-asset with an equivalent using the GitHub CLI. The CLI is available on GitHub-provided runners and can use the REST API to push an asset ([documentation](https://docs.github.com/en/rest/releases/assets?apiVersion=2022-11-28)). I haven't tried this myself, but the pieces should all be there.

I'd be happy to PR either or both of the above, further document them in an Issue, and/or put together a quick demo repo of the process.