### PR TITLE
Add Retcon instructions to app config FAQ

### DIFF
--- a/APP_CONFIG.md
+++ b/APP_CONFIG.md
@@ -110,6 +110,15 @@ Add this to `~/Library/LaunchAgents/com.maxgoedjen.Secretive.SecretAgent.plist`
 
 Log out and log in again before launching Gitkraken. Then enable "Use local SSH agent in GitKraken Preferences (Located under Preferences -> SSH)
 
+## Retcon
+
+Add this to your `~/.ssh/config` (the path should match the socket path from the setup flow).
+
+```
+Host *
+	IdentityAgent /Users/$YOUR_USERNAME/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh
+```
+
 # The app I use isn't listed here!
 
 If you know how to get it set up, please open a PR for this page and add it! Contributions are very welcome.


### PR DESCRIPTION
This PR adds instructions for using Retcon with Secretive to the app config FAQ. These are simply a copy of VS Code instructions.

(right now, the [Retcon help](http://retcon.app/help) section about SSH clients links to VSC instructions, but it'll be nicer to link to a section named Retcon!)