### PR TITLE
Zip parent directory to prevent double-zip/confusing attestation

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -48,10 +48,11 @@ jobs:
     - name: Download Zipped Artifact
       id: download
       env: 
-        ZIP_URL: ${{ steps.upload.outputs.artifact-url }}
+        ZIP_URL: ${{ steps.upload.outputs.artifact-id }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-            curl -L -H "Authorization: Bearer $GITHUB_TOKEN" $ZIP_URL > Secretive.zip
+            curl -L -H "Authorization: Bearer $GITHUB_TOKEN" -L \
+            https://api.github.com/repos/maxgoedjen/secretive/actions/artifacts/$ZIP_ID/zip > Secretive.zip
     - name: SHA Zipped Artifact
       run: shasum -a 256 Secretive.zip
     - name: Notarize

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -44,12 +44,14 @@ jobs:
         APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
         APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
       run: xcrun notarytool submit --key ~/.private_keys/AuthKey_$APPLE_API_KEY_ID.p8 --key-id $APPLE_API_KEY_ID --issuer $APPLE_API_ISSUER Secretive.zip
+    - name: Remove SecretAgent artifact
+      run: rm -r Archive.xcarchive/Products/Applications/SecretAgent.app
     - name: Upload App to Artifacts
       id: upload
       uses: actions/upload-artifact@v4
       with:
         name: Secretive.zip
-        path: Archive.xcarchive/Products/Applications/Secretive.app
+        path: Archive.xcarchive/Products/Applications
     - name: Attest
       id: attest
       uses: actions/attest-build-provenance@v2

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -49,6 +49,7 @@ jobs:
       uses: actions/download-artifact@v5
       with:
         artifact-ids: ${{ steps.upload.outputs.artifact-id }}
+      run: ls -R        
     - name: Notarize
       env: 
         APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -49,7 +49,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: Secretive.zip
-        path: Secretive.zip
+        path: Archive.xcarchive/Products/Applications/Secretive.app
     - name: Attest
       id: attest
       uses: actions/attest-build-provenance@v2

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Build
       run: xcrun xcodebuild -project Sources/Secretive.xcodeproj -scheme Secretive -configuration Release -archivePath Archive.xcarchive archive
     - name: Move to Artifact Folder
-      run: mkdir Artifact; cp Archive.xcarchive/Products/Applications/Secretive.app Artifact
+      run: mkdir Artifact; cp -r Archive.xcarchive/Products/Applications/Secretive.app Artifact
     - name: Upload App to Artifacts
       id: upload
       uses: actions/upload-artifact@v4

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -12,6 +12,7 @@ jobs:
       id-token: write
       contents: write
       attestations: write
+      actions: read
     timeout-minutes: 10
     steps:
     - uses: actions/checkout@v5
@@ -50,7 +51,7 @@ jobs:
         ZIP_URL: ${{ steps.upload.outputs.artifact-url }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-            curl -H "Authorization: Bearer $GITHUB_TOKEN" -L $ZIP_URL > Secretive.zip
+            curl -L -H "Authorization: Bearer $GITHUB_TOKEN" $ZIP_URL > Secretive.zip
     - name: SHA Zipped Artifact
       run: shasum -a 256 Secretive.zip
     - name: Notarize

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -49,13 +49,12 @@ jobs:
       uses: actions/download-artifact@v5
       with:
         artifact-ids: ${{ steps.upload.outputs.artifact-id }}
-    - name: list
-      run: ls -R        
     - name: Notarize
       env: 
         APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
         APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
-      run: xcrun notarytool submit --key ~/.private_keys/AuthKey_$APPLE_API_KEY_ID.p8 --key-id $APPLE_API_KEY_ID --issuer $APPLE_API_ISSUER Secretive.zip
+        ZIP_PATH: ${{ steps.download.outputs..download-path }}
+      run: xcrun notarytool submit --key ~/.private_keys/AuthKey_$APPLE_API_KEY_ID.p8 --key-id $APPLE_API_KEY_ID --issuer $APPLE_API_ISSUER $ZIP_PATH
     - name: Attest
       id: attest
       uses: actions/attest-build-provenance@v2

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -48,7 +48,7 @@ jobs:
       id: download
       uses: actions/download-artifact@v5
       with:
-        artifact-ids: {{ steps.upload.outputs.artifact-id }}
+        artifact-ids: ${{ steps.upload.outputs.artifact-id }}
     - name: Notarize
       env: 
         APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -49,6 +49,8 @@ jobs:
       env: 
         ZIP_URL: ${{ steps.upload.outputs.artifact-url }}
       run: curl -L $ZIP_URL > Secretive.zip
+    - name: SHA Zipped Artifact
+      run: shasum -a 256 Secretive.zip
     - name: Notarize
       env: 
         APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -36,22 +36,24 @@ jobs:
             sed -i '' -e "s/GITHUB_BUILD_URL/https:\/\/github.com\/maxgoedjen\/secretive\/actions\/runs\/$RUN_ID/g" Sources/Config/Config.xcconfig
     - name: Build
       run: xcrun xcodebuild -project Sources/Secretive.xcodeproj -scheme Secretive -configuration Release -archivePath Archive.xcarchive archive
-    - name: Create ZIP
-      run: |
-            ditto -c -k --sequesterRsrc --keepParent Archive.xcarchive/Products/Applications/Secretive.app ./Secretive.zip
-    - name: Notarize
-      env: 
-        APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
-        APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
-      run: xcrun notarytool submit --key ~/.private_keys/AuthKey_$APPLE_API_KEY_ID.p8 --key-id $APPLE_API_KEY_ID --issuer $APPLE_API_ISSUER Secretive.zip
-    - name: Remove SecretAgent artifact
-      run: rm -r Archive.xcarchive/Products/Applications/SecretAgent.app
+    - name: Move to Artifact Folder
+      run: mkdir Artifact; cp Archive.xcarchive/Products/Applications/Secretive.app
     - name: Upload App to Artifacts
       id: upload
       uses: actions/upload-artifact@v4
       with:
         name: Secretive.zip
-        path: Archive.xcarchive/Products/Applications
+        path: Artifact
+    - name: Download Zipped Artifact
+      id: download
+      uses: actions/download-artifact@v5
+      with:
+        artifact-ids: {{ steps.upload.outputs.artifact-id }}
+    - name: Notarize
+      env: 
+        APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+        APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+      run: xcrun notarytool submit --key ~/.private_keys/AuthKey_$APPLE_API_KEY_ID.p8 --key-id $APPLE_API_KEY_ID --issuer $APPLE_API_ISSUER Secretive.zip
     - name: Attest
       id: attest
       uses: actions/attest-build-provenance@v2

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -42,13 +42,14 @@ jobs:
       id: upload
       uses: actions/upload-artifact@v4
       with:
-        name: Secretive.zip
+        name: Secretive
         path: Artifact
     - name: Download Zipped Artifact
       id: download
       env: 
         ZIP_URL: ${{ steps.upload.outputs.artifact-url }}
-      run: curl -L $ZIP_URL > Secretive.zip
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: curl  -H "Authorization: Bearer $GITHUB_TOKEN" -L $ZIP_URL > Secretive.zip
     - name: SHA Zipped Artifact
       run: shasum -a 256 Secretive.zip
     - name: Notarize

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -48,7 +48,7 @@ jobs:
       id: download
       env: 
         ZIP_URL: ${{ steps.upload.outputs.artifact-url }}
-      run: curl $ZIP_URL > Secretive.zip
+      run: curl -L $ZIP_URL > Secretive.zip
     - name: Notarize
       env: 
         APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -53,8 +53,6 @@ jobs:
       run: |
             curl -L -H "Authorization: Bearer $GITHUB_TOKEN" -L \
             https://api.github.com/repos/maxgoedjen/secretive/actions/artifacts/$ZIP_ID/zip > Secretive.zip
-    - name: SHA Zipped Artifact
-      run: shasum -a 256 Secretive.zip
     - name: Notarize
       env: 
         APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -53,7 +53,7 @@ jobs:
       env: 
         APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
         APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
-        ZIP_PATH: ${{ steps.download.outputs..download-path }}
+        ZIP_PATH: ${{ steps.download.outputs.download-path }}
       run: xcrun notarytool submit --key ~/.private_keys/AuthKey_$APPLE_API_KEY_ID.p8 --key-id $APPLE_API_KEY_ID --issuer $APPLE_API_ISSUER $ZIP_PATH
     - name: Attest
       id: attest

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -48,7 +48,7 @@ jobs:
     - name: Download Zipped Artifact
       id: download
       env: 
-        ZIP_URL: ${{ steps.upload.outputs.artifact-id }}
+        ZIP_ID: ${{ steps.upload.outputs.artifact-id }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
             curl -L -H "Authorization: Bearer $GITHUB_TOKEN" -L \

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -54,7 +54,7 @@ jobs:
         APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
         APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
         ZIP_PATH: ${{ steps.download.outputs.download-path }}
-      run: xcrun notarytool submit --key ~/.private_keys/AuthKey_$APPLE_API_KEY_ID.p8 --key-id $APPLE_API_KEY_ID --issuer $APPLE_API_ISSUER $ZIP_PATH
+      run: xcrun notarytool submit --key ~/.private_keys/AuthKey_$APPLE_API_KEY_ID.p8 --key-id $APPLE_API_KEY_ID --issuer $APPLE_API_ISSUER $ZIP_PATH/Secretive.zip
     - name: Attest
       id: attest
       uses: actions/attest-build-provenance@v2

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -49,6 +49,7 @@ jobs:
       uses: actions/download-artifact@v5
       with:
         artifact-ids: ${{ steps.upload.outputs.artifact-id }}
+    - name: list
       run: ls -R        
     - name: Notarize
       env: 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -46,11 +46,9 @@ jobs:
         path: Artifact
     - name: Download Zipped Artifact
       id: download
-      uses: actions/download-artifact@v5
-      with:
-        artifact-ids: ${{ steps.upload.outputs.artifact-id }}
-    - name: list
-      run: ls -R        
+      env: 
+        ZIP_URL: ${{ steps.upload.outputs.artifact-url }}
+      run: curl $ZIP_URL > Secretive.zip
     - name: Notarize
       env: 
         APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -49,12 +49,13 @@ jobs:
       uses: actions/download-artifact@v5
       with:
         artifact-ids: ${{ steps.upload.outputs.artifact-id }}
+    - name: list
+      run: ls -R        
     - name: Notarize
       env: 
         APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
         APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
-        ZIP_PATH: ${{ steps.download.outputs.download-path }}
-      run: xcrun notarytool submit --key ~/.private_keys/AuthKey_$APPLE_API_KEY_ID.p8 --key-id $APPLE_API_KEY_ID --issuer $APPLE_API_ISSUER $ZIP_PATH/Secretive.zip
+      run: xcrun notarytool submit --key ~/.private_keys/AuthKey_$APPLE_API_KEY_ID.p8 --key-id $APPLE_API_KEY_ID --issuer $APPLE_API_ISSUER Secretive.zip
     - name: Attest
       id: attest
       uses: actions/attest-build-provenance@v2

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Build
       run: xcrun xcodebuild -project Sources/Secretive.xcodeproj -scheme Secretive -configuration Release -archivePath Archive.xcarchive archive
     - name: Move to Artifact Folder
-      run: mkdir Artifact; cp Archive.xcarchive/Products/Applications/Secretive.app
+      run: mkdir Artifact; cp Archive.xcarchive/Products/Applications/Secretive.app Artifact
     - name: Upload App to Artifacts
       id: upload
       uses: actions/upload-artifact@v4

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -49,7 +49,7 @@ jobs:
       env: 
         ZIP_URL: ${{ steps.upload.outputs.artifact-url }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: curl  -H "Authorization: Bearer $GITHUB_TOKEN" -L $ZIP_URL > Secretive.zip
+      run: curl  -H "Authorization:\ Bearer $GITHUB_TOKEN" -L $ZIP_URL > Secretive.zip
     - name: SHA Zipped Artifact
       run: shasum -a 256 Secretive.zip
     - name: Notarize

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -49,7 +49,8 @@ jobs:
       env: 
         ZIP_URL: ${{ steps.upload.outputs.artifact-url }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: curl  -H "Authorization:\ Bearer $GITHUB_TOKEN" -L $ZIP_URL > Secretive.zip
+      run: |
+            curl -H "Authorization: Bearer $GITHUB_TOKEN" -L $ZIP_URL > Secretive.zip
     - name: SHA Zipped Artifact
       run: shasum -a 256 Secretive.zip
     - name: Notarize

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,26 +58,28 @@ jobs:
             sed -i '' -e "s/GITHUB_BUILD_URL/github.com\/maxgoedjen\/secretive\/actions\/runs\/$RUN_ID/g" Sources/Config/Config.xcconfig
     - name: Build
       run: xcrun xcodebuild -project Sources/Secretive.xcodeproj -scheme Secretive -configuration Release -archivePath Archive.xcarchive archive
-    - name: Create ZIP
-      run: |
-            ditto -c -k --sequesterRsrc --keepParent Archive.xcarchive/Products/Applications/Secretive.app ./Secretive.zip
-    - name: Notarize
-      env: 
-        APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
-        APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
-      run: xcrun notarytool submit --key ~/.private_keys/AuthKey_$APPLE_API_KEY_ID.p8 --key-id $APPLE_API_KEY_ID --issuer $APPLE_API_ISSUER Secretive.zip
     - name: Upload App to Artifacts
       id: upload
       uses: actions/upload-artifact@v4
       with:
         name: Secretive.zip
         path: Secretive.zip
+    - name: Download Zipped Artifact
+      id: download
+      uses: actions/download-artifact@v5
+      with:
+        artifact-ids: {{ steps.upload.outputs.artifact-id }}
     - name: Attest
       id: attest
       uses: actions/attest-build-provenance@v2
       with:
         subject-name: "Secretive.zip"
         subject-digest: sha256:${{ steps.upload.outputs.artifact-digest }}
+    - name: Notarize
+      env: 
+        APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+        APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+      run: xcrun notarytool submit --key ~/.private_keys/AuthKey_$APPLE_API_KEY_ID.p8 --key-id $APPLE_API_KEY_ID --issuer $APPLE_API_ISSUER Secretive.zip
     - name: Create Release
       run: |
             sed -i.tmp "s/RUN_ID/$RUN_ID/g" .github/templates/release.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,9 @@ jobs:
       id: download
       env: 
         ZIP_URL: ${{ steps.upload.outputs.artifact-url }}
-      run: curl -L $ZIP_URL > Secretive.zip; shasum -a 256 Secretive.zip
+      run: curl -L $ZIP_URL > Secretive.zip
+    - name: SHA Zipped Artifact
+      run: shasum -a 256 Secretive.zip
     - name: Notarize
       env: 
         APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,9 +68,9 @@ jobs:
         path: Artifact
     - name: Download Zipped Artifact
       id: download
-      uses: actions/download-artifact@v5
-      with:
-        artifact-ids: ${{ steps.upload.outputs.artifact-id }}
+      env: 
+        ZIP_URL: ${{ steps.upload.outputs.artifact-url }}
+      run: curl -L $ZIP_URL > Secretive.zip
     - name: Notarize
       env: 
         APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
     - name: Build
       run: xcrun xcodebuild -project Sources/Secretive.xcodeproj -scheme Secretive -configuration Release -archivePath Archive.xcarchive archive
     - name: Move to Artifact Folder
-      run: mkdir Artifact; cp Archive.xcarchive/Products/Applications/Secretive.app
+      run: mkdir Artifact; cp Archive.xcarchive/Products/Applications/Secretive.app Artifact
     - name: Upload App to Artifacts
       id: upload
       uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,28 +58,30 @@ jobs:
             sed -i '' -e "s/GITHUB_BUILD_URL/github.com\/maxgoedjen\/secretive\/actions\/runs\/$RUN_ID/g" Sources/Config/Config.xcconfig
     - name: Build
       run: xcrun xcodebuild -project Sources/Secretive.xcodeproj -scheme Secretive -configuration Release -archivePath Archive.xcarchive archive
+    - name: Move to Artifact Folder
+      run: mkdir Artifact; cp Archive.xcarchive/Products/Applications/Secretive.app
     - name: Upload App to Artifacts
       id: upload
       uses: actions/upload-artifact@v4
       with:
         name: Secretive.zip
-        path: Secretive.zip
+        path: Artifact
     - name: Download Zipped Artifact
       id: download
       uses: actions/download-artifact@v5
       with:
         artifact-ids: {{ steps.upload.outputs.artifact-id }}
+    - name: Notarize
+      env: 
+        APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+        APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+      run: xcrun notarytool submit --key ~/.private_keys/AuthKey_$APPLE_API_KEY_ID.p8 --key-id $APPLE_API_KEY_ID --issuer $APPLE_API_ISSUER Secretive.zip
     - name: Attest
       id: attest
       uses: actions/attest-build-provenance@v2
       with:
         subject-name: "Secretive.zip"
         subject-digest: sha256:${{ steps.upload.outputs.artifact-digest }}
-    - name: Notarize
-      env: 
-        APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
-        APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
-      run: xcrun notarytool submit --key ~/.private_keys/AuthKey_$APPLE_API_KEY_ID.p8 --key-id $APPLE_API_KEY_ID --issuer $APPLE_API_ISSUER Secretive.zip
     - name: Create Release
       run: |
             sed -i.tmp "s/RUN_ID/$RUN_ID/g" .github/templates/release.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
       id: download
       uses: actions/download-artifact@v5
       with:
-        artifact-ids: {{ steps.upload.outputs.artifact-id }}
+        artifact-ids: ${{ steps.upload.outputs.artifact-id }}
     - name: Notarize
       env: 
         APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
     - name: Build
       run: xcrun xcodebuild -project Sources/Secretive.xcodeproj -scheme Secretive -configuration Release -archivePath Archive.xcarchive archive
     - name: Move to Artifact Folder
-      run: mkdir Artifact; cp Archive.xcarchive/Products/Applications/Secretive.app Artifact
+      run: mkdir Artifact; cp -r Archive.xcarchive/Products/Applications/Secretive.app Artifact
     - name: Upload App to Artifacts
       id: upload
       uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,8 +71,6 @@ jobs:
       env: 
         ZIP_URL: ${{ steps.upload.outputs.artifact-url }}
       run: curl -L $ZIP_URL > Secretive.zip
-    - name: SHA Zipped Artifact
-      run: shasum -a 256 Secretive.zip
     - name: Notarize
       env: 
         APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,7 @@ jobs:
       id-token: write
       contents: write
       attestations: write
+      actions: read
     runs-on: macos-26
     timeout-minutes: 10
     steps:
@@ -69,8 +70,11 @@ jobs:
     - name: Download Zipped Artifact
       id: download
       env: 
-        ZIP_URL: ${{ steps.upload.outputs.artifact-url }}
-      run: curl -L $ZIP_URL > Secretive.zip
+        ZIP_ID: ${{ steps.upload.outputs.artifact-id }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+            curl -L -H "Authorization: Bearer $GITHUB_TOKEN" -L \
+            https://api.github.com/repos/maxgoedjen/secretive/actions/artifacts/$ZIP_ID/zip > Secretive.zip
     - name: Notarize
       env: 
         APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
@@ -83,13 +87,13 @@ jobs:
         subject-name: "Secretive.zip"
         subject-digest: sha256:${{ steps.upload.outputs.artifact-digest }}
     - name: Create Release
-      run: |
-            sed -i.tmp "s/RUN_ID/$RUN_ID/g" .github/templates/release.md
-            sed -i.tmp "s/ATTESTATION_ID/$ATTESTATION_ID/g" .github/templates/release.md
-            gh release create $TAG_NAME -d -F .github/templates/release.md
-            gh release upload $TAG_NAME Secretive.zip
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         TAG_NAME: ${{ github.ref }}
         RUN_ID: ${{ github.run_id }}
         ATTESTATION_ID: ${{ steps.attest.outputs.attestation-id }}
+      run: |
+            sed -i.tmp "s/RUN_ID/$RUN_ID/g" .github/templates/release.md
+            sed -i.tmp "s/ATTESTATION_ID/$ATTESTATION_ID/g" .github/templates/release.md
+            gh release create $TAG_NAME -d -F .github/templates/release.md
+            gh release upload $TAG_NAME Secretive.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
       id: download
       env: 
         ZIP_URL: ${{ steps.upload.outputs.artifact-url }}
-      run: curl -L $ZIP_URL > Secretive.zip
+      run: curl -L $ZIP_URL > Secretive.zip; shasum -a 256 Secretive.zip
     - name: Notarize
       env: 
         APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}


### PR DESCRIPTION
Currently I prezip to prevent a weird situation where a GitHub zipped artifact will expand and just show the "Contents" directory of the `.app` – this is avoidable by uploading a folder containing the .app instead of the .app itself.

Fixes #730 
