### PR TITLE
Serialize sign calls that require auth prompt (#776)

### DIFF
--- a/Sources/Packages/Sources/SecureEnclaveSecretKit/SigningSerializer.swift
+++ b/Sources/Packages/Sources/SecureEnclaveSecretKit/SigningSerializer.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+/// Serializes signing operations for protected keys to prevent LAContext conflicts.
+/// macOS only allows one biometric authentication prompt at a time, so concurrent
+/// requests for protected Secure Enclave keys must be queued.
+actor SigningSerializer {
+    private var isProcessing = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func serialize<T: Sendable>(operation: @escaping @Sendable () async throws -> T) async throws -> T {
+        // If someone is already processing, wait in line
+        if isProcessing {
+            await withCheckedContinuation { continuation in
+                waiters.append(continuation)
+            }
+        }
+
+        isProcessing = true
+
+        defer {
+            if let next = waiters.first {
+                waiters.removeFirst()
+                next.resume()
+            } else {
+                isProcessing = false
+            }
+        }
+
+        return try await operation()
+    }
+}


### PR DESCRIPTION
Newer Secure Enclave authentication requests cancel any in-flight request. When multiple signing requests arrive concurrently for the same protected key, this results in overlapping authentication prompts and causes all but the most recent request to fail.

This change serializes authentication requests so that:
- Only one Secure Enclave authentication prompt is active at a time
- Additional signing requests are queued while authentication is in progress
- Queued requests are processed in order once authentication completes

Fixes: https://github.com/maxgoedjen/secretive/issues/532