### PR TITLE
1:M key:cert support

### DIFF
--- a/Sources/Config/Secretive.xctestplan
+++ b/Sources/Config/Secretive.xctestplan
@@ -32,6 +32,27 @@
         "identifier" : "SecretAgentKitTests",
         "name" : "SecretAgentKitTests"
       }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:Packages",
+        "identifier" : "SSHProtocolKitTests",
+        "name" : "SSHProtocolKitTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:Packages",
+        "identifier" : "XPCWrappersTests",
+        "name" : "XPCWrappersTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:Packages",
+        "identifier" : "CommonTests",
+        "name" : "CommonTests"
+      }
     }
   ],
   "version" : 1

--- a/Sources/Packages/Package.swift
+++ b/Sources/Packages/Package.swift
@@ -88,9 +88,13 @@ let package = Package(
             resources: [localization],
             swiftSettings: swiftSettings,
         ),
+        .testTarget(
+            name: "CommonTests",
+            dependencies: ["Common"],
+        ),
         .target(
             name: "Brief",
-            dependencies: ["XPCWrappers", "SSHProtocolKit"],
+            dependencies: ["Common", "XPCWrappers", "SSHProtocolKit"],
             resources: [localization],
             swiftSettings: swiftSettings,
         ),
@@ -101,6 +105,10 @@ let package = Package(
         .target(
             name: "XPCWrappers",
             swiftSettings: swiftSettings,
+        ),
+        .testTarget(
+            name: "XPCWrappersTests",
+            dependencies: ["XPCWrappers"],
         ),
     ]
 )

--- a/Sources/Packages/Sources/Brief/Updater.swift
+++ b/Sources/Packages/Sources/Brief/Updater.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Observation
 import XPCWrappers
+import Common
 
 /// A concrete implementation of ``UpdaterProtocol`` which considers the current release and OS version.
 @Observable public final class Updater: UpdaterProtocol, Sendable {
@@ -47,7 +48,7 @@ import XPCWrappers
 
     /// Manually trigger an update check.
     public func checkForUpdates() async throws {
-        let session = try await XPCTypedSession<[Release], Never>(serviceName: "com.maxgoedjen.Secretive.SecretiveUpdater")
+        let session = try await XPCTypedSession<[Release], Never>(serviceName: Bundle.secretiveUpdaterServiceBundleID)
         await evaluate(releases: try await session.send())
         session.complete()
     }

--- a/Sources/Packages/Sources/Common/BundleIDs.swift
+++ b/Sources/Packages/Sources/Common/BundleIDs.swift
@@ -1,11 +1,35 @@
 import Foundation
 
 extension Bundle {
+    static func replacingLastBundleComponent(in bundleID: String, with replacement: String) -> String {
+        guard let separator = bundleID.lastIndex(of: ".") else {
+            preconditionFailure("Expected a bundle identifier with at least two components.")
+        }
+
+        return "\(bundleID[..<separator]).\(replacement)"
+    }
+
+    private static var mainBundleID: String {
+        guard let bundleIdentifier = Bundle.main.bundleIdentifier else {
+            preconditionFailure("Expected the main bundle to have a bundle identifier.")
+        }
+
+        return bundleIdentifier
+    }
+
     public static var agentBundleID: String {
-        Bundle.main.bundleIdentifier!.replacingOccurrences(of: "Host", with: "SecretAgent")
+        replacingLastBundleComponent(in: mainBundleID, with: "SecretAgent")
     }
 
     public static var hostBundleID: String {
-        Bundle.main.bundleIdentifier!.replacingOccurrences(of: "SecretAgent", with: "Host")
+        replacingLastBundleComponent(in: mainBundleID, with: "Host")
+    }
+
+    public static var secretAgentInputParserServiceBundleID: String {
+        replacingLastBundleComponent(in: mainBundleID, with: "SecretAgentInputParser")
+    }
+
+    public static var secretiveUpdaterServiceBundleID: String {
+        replacingLastBundleComponent(in: mainBundleID, with: "SecretiveUpdater")
     }
 }

--- a/Sources/Packages/Sources/SSHProtocolKit/OpenSSHCertificateReader.swift
+++ b/Sources/Packages/Sources/SSHProtocolKit/OpenSSHCertificateReader.swift
@@ -1,0 +1,193 @@
+import Foundation
+
+/// Reads OpenSSH certificate blobs and their corresponding public-key lines.
+public struct OpenSSHCertificateReader: Sendable {
+
+    /// Initializes the reader.
+    public init() {
+    }
+
+    /// Parses an OpenSSH public key line containing a certificate.
+    /// - Parameter line: A line in `<type> <base64> [comment]` format.
+    /// - Returns: A parsed certificate.
+    public func readPublicKeyLine(_ line: String) throws(OpenSSHCertificateError) -> ParsedCertificate {
+        let parts = line
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .split(maxSplits: 2, omittingEmptySubsequences: true, whereSeparator: \.isWhitespace)
+        guard parts.count >= 2 else {
+            throw .invalidPublicKeyLine
+        }
+        guard let certificateBlob = Data(base64Encoded: String(parts[1])) else {
+            throw .parsingFailed
+        }
+        var parsedCertificate = try readCertificateBlob(certificateBlob)
+        let declaredType = String(parts[0])
+        guard declaredType == parsedCertificate.type else {
+            throw .typeMismatch
+        }
+        if parts.count == 3 {
+            parsedCertificate.comment = String(parts[2])
+        }
+        return parsedCertificate
+    }
+
+    /// Parses a raw OpenSSH certificate blob.
+    /// - Parameter blob: The SSH wire-format certificate blob.
+    /// - Returns: A parsed certificate.
+    public func readCertificateBlob(_ blob: Data) throws(OpenSSHCertificateError) -> ParsedCertificate {
+        let reader = OpenSSHReader(data: blob)
+        do {
+            let certificateType = try reader.readNextChunkAsString()
+            _ = try reader.readNextChunk() // nonce
+            let subjectKeyBlob = try subjectKeyBlob(from: reader, certificateType: certificateType)
+            let validity = try readSharedCertificateFields(reader)
+            return ParsedCertificate(
+                certificateBlob: blob,
+                subjectKeyBlob: subjectKeyBlob,
+                subjectKeyFingerprint: OpenSSHKeyFingerprint.sha256(for: subjectKeyBlob),
+                comment: nil,
+                type: certificateType,
+                validAfter: validity.validAfter,
+                validBefore: validity.validBefore
+            )
+        } catch let certificateError as OpenSSHCertificateError {
+            throw certificateError
+        } catch {
+            throw .parsingFailed
+        }
+    }
+
+}
+
+extension OpenSSHCertificateReader {
+
+    private func subjectKeyBlob(from reader: OpenSSHReader, certificateType: String) throws(OpenSSHCertificateError) -> Data {
+        switch certificateType {
+        case let type where type.hasPrefix("ecdsa-sha2-") && type.hasSuffix("-cert-v01@openssh.com"):
+            let curveIdentifier = try readChunk(from: reader)
+            let publicKey = try readChunk(from: reader)
+            let openSSHIdentifier = type.replacingOccurrences(of: "-cert-v01@openssh.com", with: "")
+            return openSSHIdentifier.lengthAndData +
+            curveIdentifier.lengthAndData +
+            publicKey.lengthAndData
+        case "ssh-rsa-cert-v01@openssh.com",
+            "rsa-sha2-256-cert-v01@openssh.com",
+            "rsa-sha2-512-cert-v01@openssh.com":
+            let exponent = try readChunk(from: reader)
+            let modulus = try readChunk(from: reader)
+            return "ssh-rsa".lengthAndData +
+            exponent.lengthAndData +
+            modulus.lengthAndData
+        case let type where type.hasPrefix("ssh-mldsa-") && type.hasSuffix("-cert-v01@openssh.com"),
+            let type where type.hasPrefix("ssh-ed25519-") && type.hasSuffix("-cert-v01@openssh.com"):
+            let publicKey = try readChunk(from: reader)
+            let openSSHIdentifier = type.replacingOccurrences(of: "-cert-v01@openssh.com", with: "")
+            return openSSHIdentifier.lengthAndData + publicKey.lengthAndData
+        default:
+            throw .unsupportedType
+        }
+    }
+
+    private func readSharedCertificateFields(_ reader: OpenSSHReader) throws(OpenSSHCertificateError) -> CertificateValidity {
+        do {
+            _ = try reader.readNextBytes(as: UInt64.self) // serial
+            _ = try reader.readNextBytes(as: UInt32.self) // cert type
+            _ = try reader.readNextChunk() // key ID
+            _ = try reader.readNextChunk() // valid principals
+            let validAfter = try reader.readNextBytes(as: UInt64.self)
+            let validBefore = try reader.readNextBytes(as: UInt64.self)
+            _ = try reader.readNextChunk() // critical options
+            _ = try reader.readNextChunk() // extensions
+            _ = try reader.readNextChunk() // reserved
+            _ = try reader.readNextChunk() // signature key
+            _ = try reader.readNextChunk() // signature
+            guard reader.done else {
+                throw OpenSSHCertificateError.parsingFailed
+            }
+            return CertificateValidity(validAfter: validAfter, validBefore: validBefore)
+        } catch {
+            throw .parsingFailed
+        }
+    }
+
+    private func readChunk(from reader: OpenSSHReader) throws(OpenSSHCertificateError) -> Data {
+        do {
+            return try reader.readNextChunk()
+        } catch {
+            throw .parsingFailed
+        }
+    }
+
+}
+
+extension OpenSSHCertificateReader {
+
+    private struct CertificateValidity {
+        let validAfter: UInt64
+        let validBefore: UInt64
+    }
+
+}
+
+extension OpenSSHCertificateReader {
+
+    /// The parsed contents of an OpenSSH certificate.
+    public struct ParsedCertificate: Sendable, Hashable {
+        public let certificateBlob: Data
+        public let subjectKeyBlob: Data
+        public let subjectKeyFingerprint: String
+        public var comment: String?
+        public let type: String
+        public let validAfter: UInt64
+        public let validBefore: UInt64
+
+        public init(
+            certificateBlob: Data,
+            subjectKeyBlob: Data,
+            subjectKeyFingerprint: String,
+            comment: String?,
+            type: String,
+            validAfter: UInt64,
+            validBefore: UInt64
+        ) {
+            self.certificateBlob = certificateBlob
+            self.subjectKeyBlob = subjectKeyBlob
+            self.subjectKeyFingerprint = subjectKeyFingerprint
+            self.comment = comment
+            self.type = type
+            self.validAfter = validAfter
+            self.validBefore = validBefore
+        }
+
+        public func isExpired(at date: Date = .now) -> Bool {
+            guard validBefore != .max else {
+                return false
+            }
+
+            let currentTimestamp = max(0, Int64(date.timeIntervalSince1970))
+            return validBefore <= UInt64(currentTimestamp)
+        }
+    }
+
+    /// Errors produced while parsing OpenSSH certificates.
+    public enum OpenSSHCertificateError: LocalizedError, Equatable {
+        case unsupportedType
+        case invalidPublicKeyLine
+        case parsingFailed
+        case typeMismatch
+
+        public var errorDescription: String? {
+            switch self {
+            case .unsupportedType:
+                "The certificate type was unsupported."
+            case .invalidPublicKeyLine:
+                "The public key line was invalid."
+            case .parsingFailed:
+                "The certificate could not be parsed."
+            case .typeMismatch:
+                "The declared key type did not match the certificate blob."
+            }
+        }
+    }
+
+}

--- a/Sources/Packages/Sources/SSHProtocolKit/OpenSSHPublicKeyReader.swift
+++ b/Sources/Packages/Sources/SSHProtocolKit/OpenSSHPublicKeyReader.swift
@@ -1,0 +1,138 @@
+import Foundation
+
+/// Reads OpenSSH public key blobs and their corresponding public-key lines.
+public struct OpenSSHPublicKeyReader: Sendable {
+
+    /// Initializes the reader.
+    public init() {
+    }
+
+    /// Parses an OpenSSH public key line.
+    /// - Parameter line: A line in `<type> <base64> [comment]` format.
+    /// - Returns: A parsed public key.
+    public func readPublicKeyLine(_ line: String) throws(OpenSSHPublicKeyError) -> ParsedPublicKey {
+        let parts = line
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .split(maxSplits: 2, omittingEmptySubsequences: true, whereSeparator: \.isWhitespace)
+        guard parts.count >= 2 else {
+            throw .invalidPublicKeyLine
+        }
+        guard let keyBlob = Data(base64Encoded: String(parts[1])) else {
+            throw .parsingFailed
+        }
+        var parsedPublicKey = try readPublicKeyBlob(keyBlob)
+        let declaredType = String(parts[0])
+        guard declaredType == parsedPublicKey.type else {
+            throw .typeMismatch
+        }
+        if parts.count == 3 {
+            parsedPublicKey.comment = String(parts[2])
+        }
+        return parsedPublicKey
+    }
+
+    /// Parses a raw OpenSSH public key blob.
+    /// - Parameter blob: The SSH wire-format public key blob.
+    /// - Returns: A parsed public key.
+    public func readPublicKeyBlob(_ blob: Data) throws(OpenSSHPublicKeyError) -> ParsedPublicKey {
+        let reader = OpenSSHReader(data: blob)
+        do {
+            let keyType = try reader.readNextChunkAsString()
+            try validatePublicKeyBody(reader, keyType: keyType)
+            return ParsedPublicKey(
+                keyBlob: blob,
+                fingerprint: OpenSSHKeyFingerprint.sha256(for: blob),
+                comment: nil,
+                type: keyType
+            )
+        } catch let publicKeyError as OpenSSHPublicKeyError {
+            throw publicKeyError
+        } catch {
+            throw .parsingFailed
+        }
+    }
+
+}
+
+extension OpenSSHPublicKeyReader {
+
+    private func validatePublicKeyBody(_ reader: OpenSSHReader, keyType: String) throws(OpenSSHPublicKeyError) {
+        switch keyType {
+        case let type where type.hasPrefix("ecdsa-sha2-") && !type.hasSuffix("-cert-v01@openssh.com"):
+            _ = try readChunk(from: reader)
+            _ = try readChunk(from: reader)
+        case "ssh-rsa":
+            _ = try readChunk(from: reader)
+            _ = try readChunk(from: reader)
+        case "ssh-ed25519":
+            _ = try readChunk(from: reader)
+        case let type where type.hasPrefix("ssh-mldsa-") && !type.hasSuffix("-cert-v01@openssh.com"):
+            _ = try readChunk(from: reader)
+        case let type where type.hasSuffix("-cert-v01@openssh.com"):
+            throw .certificateType
+        default:
+            throw .unsupportedType
+        }
+
+        guard reader.done else {
+            throw .parsingFailed
+        }
+    }
+
+    private func readChunk(from reader: OpenSSHReader) throws(OpenSSHPublicKeyError) -> Data {
+        do {
+            return try reader.readNextChunk()
+        } catch {
+            throw .parsingFailed
+        }
+    }
+
+}
+
+extension OpenSSHPublicKeyReader {
+
+    /// The parsed contents of an OpenSSH public key.
+    public struct ParsedPublicKey: Sendable, Hashable {
+        public let keyBlob: Data
+        public let fingerprint: String
+        public var comment: String?
+        public let type: String
+
+        public init(
+            keyBlob: Data,
+            fingerprint: String,
+            comment: String?,
+            type: String
+        ) {
+            self.keyBlob = keyBlob
+            self.fingerprint = fingerprint
+            self.comment = comment
+            self.type = type
+        }
+    }
+
+    /// Errors produced while parsing OpenSSH public keys.
+    public enum OpenSSHPublicKeyError: LocalizedError, Equatable {
+        case unsupportedType
+        case certificateType
+        case invalidPublicKeyLine
+        case parsingFailed
+        case typeMismatch
+
+        public var errorDescription: String? {
+            switch self {
+            case .unsupportedType:
+                "The public key type was unsupported."
+            case .certificateType:
+                "The blob was an OpenSSH certificate, not a bare public key."
+            case .invalidPublicKeyLine:
+                "The public key line was invalid."
+            case .parsingFailed:
+                "The public key could not be parsed."
+            case .typeMismatch:
+                "The declared key type did not match the public key blob."
+            }
+        }
+    }
+
+}

--- a/Sources/Packages/Sources/SSHProtocolKit/OpenSSHPublicKeyWriter.swift
+++ b/Sources/Packages/Sources/SSHProtocolKit/OpenSSHPublicKeyWriter.swift
@@ -40,17 +40,13 @@ public struct OpenSSHPublicKeyWriter: Sendable {
     /// Generates an OpenSSH SHA256 fingerprint string.
     /// - Returns: OpenSSH SHA256 fingerprint string.
     public func openSSHSHA256Fingerprint<SecretType: Secret>(secret: SecretType) -> String {
-        // OpenSSL format seems to strip the padding at the end.
-        let base64 = Data(SHA256.hash(data: data(secret: secret))).base64EncodedString()
-        let paddingRange = base64.index(base64.endIndex, offsetBy: -2)..<base64.endIndex
-        let cleaned = base64.replacingOccurrences(of: "=", with: "", range: paddingRange)
-        return "SHA256:\(cleaned)"
+        OpenSSHKeyFingerprint.sha256(for: data(secret: secret))
     }
 
     /// Generates an OpenSSH MD5 fingerprint string.
     /// - Returns: OpenSSH MD5 fingerprint string.
     public func openSSHMD5Fingerprint<SecretType: Secret>(secret: SecretType) -> String {
-        Insecure.MD5.hash(data: data(secret: secret)).formatted(.hex(separator: ":"))
+        OpenSSHKeyFingerprint.md5(for: data(secret: secret))
     }
 
     public func comment<SecretType: Secret>(secret: SecretType) -> String {
@@ -90,6 +86,21 @@ extension OpenSSHPublicKeyWriter {
         default:
             "unknown"
         }
+    }
+
+}
+
+enum OpenSSHKeyFingerprint {
+
+    static func sha256(for keyBlob: Data) -> String {
+        let base64 = Data(SHA256.hash(data: keyBlob)).base64EncodedString()
+        let paddingRange = base64.index(base64.endIndex, offsetBy: -2)..<base64.endIndex
+        let cleaned = base64.replacingOccurrences(of: "=", with: "", range: paddingRange)
+        return "SHA256:\(cleaned)"
+    }
+
+    static func md5(for keyBlob: Data) -> String {
+        Insecure.MD5.hash(data: keyBlob).formatted(.hex(separator: ":"))
     }
 
 }

--- a/Sources/Packages/Sources/SecretAgentKit/Agent.swift
+++ b/Sources/Packages/Sources/SecretAgentKit/Agent.swift
@@ -12,19 +12,24 @@ public final class Agent: Sendable {
     private let witness: SigningWitness?
     private let publicKeyWriter = OpenSSHPublicKeyWriter()
     private let signatureWriter = OpenSSHSignatureWriter()
-    private let certificateHandler = OpenSSHCertificateHandler()
+    private let certificateHandler: OpenSSHCertificateHandler
     private let logger = Logger(subsystem: "com.maxgoedjen.secretive.secretagent", category: "Agent")
 
     /// Initializes an agent with a store list and a witness.
     /// - Parameters:
     ///   - storeList: The `SecretStoreList` to make available.
     ///   - witness: A witness to notify of requests.
-    public init(storeList: SecretStoreList, witness: SigningWitness? = nil) {
+    public init(
+        storeList: SecretStoreList,
+        witness: SigningWitness? = nil,
+        certificateHandler: OpenSSHCertificateHandler = OpenSSHCertificateHandler()
+    ) {
         logger.debug("Agent is running")
         self.storeList = storeList
         self.witness = witness
-        Task { @MainActor in
-            await certificateHandler.reloadCertificates(for: storeList.allSecrets)
+        self.certificateHandler = certificateHandler
+        Task {
+            await certificateHandler.reloadCertificates()
         }
     }
     
@@ -67,8 +72,8 @@ extension Agent {
     /// Lists the identities available for signing operations
     /// - Returns: An OpenSSH formatted Data payload listing the identities available for signing operations.
     func identities() async -> Data {
+        await certificateHandler.reloadCertificates()
         let secrets = await storeList.allSecrets
-        await certificateHandler.reloadCertificates(for: secrets)
         var count = 0
         var keyData = Data()
 
@@ -78,9 +83,9 @@ extension Agent {
             keyData.append(publicKeyWriter.comment(secret: secret).lengthAndData)
             count += 1
 
-            if let (certificateData, name) = try? await certificateHandler.keyBlobAndName(for: secret) {
-                keyData.append(certificateData.lengthAndData)
-                keyData.append(name.lengthAndData)
+            for certificateIdentity in await certificateHandler.certificateIdentities(for: secret) {
+                keyData.append(certificateIdentity.keyBlob.lengthAndData)
+                keyData.append(certificateIdentity.comment.lengthAndData)
                 count += 1
             }
         }

--- a/Sources/Packages/Sources/SecretAgentKit/OpenSSHCertificateHandler.swift
+++ b/Sources/Packages/Sources/SecretAgentKit/OpenSSHCertificateHandler.swift
@@ -2,87 +2,87 @@ import Foundation
 import OSLog
 import SecretKit
 import SSHProtocolKit
+import Common
 
 /// Manages storage and lookup for OpenSSH certificates.
 public actor OpenSSHCertificateHandler: Sendable {
-
-    private let publicKeyFileStoreController = PublicKeyFileStoreController(directory: URL.publicKeyDirectory)
+    private let directory: URL
+    private let certificateReader: OpenSSHCertificateReader
+    private let publicKeyWriter: OpenSSHPublicKeyWriter
     private let logger = Logger(subsystem: "com.maxgoedjen.secretive.secretagent", category: "OpenSSHCertificateHandler")
-    private let writer = OpenSSHPublicKeyWriter()
-    private var keyBlobsAndNames: [AnySecret: (Data, Data)] = [:]
+    private var certificatesByFingerprint: [String: [OpenSSHCertificateReader.ParsedCertificate]] = [:]
 
     /// Initializes an OpenSSHCertificateHandler.
-    public init() {
+    public init(
+        directory: URL = URL.publicKeyDirectory,
+        certificateReader: OpenSSHCertificateReader = .init(),
+        publicKeyWriter: OpenSSHPublicKeyWriter = .init()
+    ) {
+        self.directory = directory
+        self.certificateReader = certificateReader
+        self.publicKeyWriter = publicKeyWriter
     }
 
     /// Reloads any certificates in the PublicKeys folder.
-    /// - Parameter secrets: the secrets to look up corresponding certificates for.
-    public func reloadCertificates(for secrets: [AnySecret]) {
-        guard publicKeyFileStoreController.hasAnyCertificates else {
-            logger.log("No certificates, short circuiting")
+    public func reloadCertificates() {
+        certificatesByFingerprint = [:]
+
+        let fileURLs: [URL]
+        do {
+            fileURLs = try FileManager.default
+                .contentsOfDirectory(at: directory, includingPropertiesForKeys: [.isRegularFileKey], options: [.skipsHiddenFiles])
+                .sorted { $0.lastPathComponent < $1.lastPathComponent }
+        } catch {
+            logger.debug("No readable certificate directory found at \(self.directory.path(), privacy: .public)")
             return
         }
-        keyBlobsAndNames = secrets.reduce(into: [:]) { partialResult, next in
-            partialResult[next] = try? loadKeyblobAndName(for: next)
+
+        for fileURL in fileURLs {
+            do {
+                let values = try fileURL.resourceValues(forKeys: [.isRegularFileKey])
+                guard values.isRegularFile == true else {
+                    continue
+                }
+
+                let contents = try String(contentsOf: fileURL, encoding: .utf8)
+                let parsedCertificate = try certificateReader.readPublicKeyLine(contents)
+                certificatesByFingerprint[parsedCertificate.subjectKeyFingerprint, default: []].append(
+                    parsedCertificate
+                )
+            } catch OpenSSHCertificateReader.OpenSSHCertificateError.unsupportedType,
+                OpenSSHCertificateReader.OpenSSHCertificateError.invalidPublicKeyLine {
+                continue
+            } catch {
+                logger.warning("Failed to load certificate from \(fileURL.lastPathComponent, privacy: .public)")
+            }
         }
     }
 
-    /// Attempts to find an OpenSSH Certificate  that corresponds to a ``Secret``
-    /// - Parameter secret: The secret to search for a certificate with
-    /// - Returns: A (``Data``, ``Data``) tuple containing the certificate and certificate name, respectively.
-    public func keyBlobAndName<SecretType: Secret>(for secret: SecretType) throws -> (Data, Data)? {
-        keyBlobsAndNames[AnySecret(secret)]
-    }
-    
-    /// Attempts to find an OpenSSH Certificate  that corresponds to a ``Secret``
-    /// - Parameter secret: The secret to search for a certificate with
-    /// - Returns: A (``Data``, ``Data``) tuple containing the certificate and certificate name, respectively.
-    private func loadKeyblobAndName<SecretType: Secret>(for secret: SecretType) throws -> (Data, Data)? {
-        let certificatePath = publicKeyFileStoreController.sshCertificatePath(for: secret)
-        guard FileManager.default.fileExists(atPath: certificatePath) else {
-            return nil
+    /// Returns all certificates that correspond to a ``Secret``.
+    /// - Parameter secret: The secret to search for certificates with.
+    /// - Returns: The certificate identities that correspond to the secret.
+    public func certificateIdentities<SecretType: Secret>(for secret: SecretType) -> [OpenSSHCertificateIdentity] {
+        let fingerprint = publicKeyWriter.openSSHSHA256Fingerprint(secret: secret)
+        return certificatesByFingerprint[fingerprint, default: []].map {
+            OpenSSHCertificateIdentity(
+                keyBlob: $0.certificateBlob,
+                comment: Data(($0.comment ?? secret.name).utf8)
+            )
         }
-
-        logger.debug("Found certificate for \(secret.name)")
-        let certContent = try String(contentsOfFile:certificatePath, encoding: .utf8)
-        let certElements = certContent.trimmingCharacters(in: .whitespacesAndNewlines).components(separatedBy: " ")
-
-        guard certElements.count >= 2 else {
-            logger.warning("Certificate found for \(secret.name) but failed to load")
-            throw OpenSSHCertificateError.parsingFailed
-        }
-        guard let certDecoded = Data(base64Encoded: certElements[1] as String)  else {
-            logger.warning("Certificate found for \(secret.name) but failed to decode base64 key")
-            throw OpenSSHCertificateError.parsingFailed
-        }
-
-        if certElements.count >= 3 {
-            let certName = Data(certElements[2].utf8)
-            return (certDecoded, certName)
-        }
-        let certName = Data(secret.name.utf8)
-        logger.info("Certificate for \(secret.name) does not have a name tag, using secret name instead")
-        return (certDecoded, certName)
     }
 
 }
 
 extension OpenSSHCertificateHandler {
 
-    enum OpenSSHCertificateError: LocalizedError {
-        case unsupportedType
-        case parsingFailed
-        case doesNotExist
+    /// An OpenSSH certificate identity advertised by the agent.
+    public struct OpenSSHCertificateIdentity: Sendable, Hashable {
+        public let keyBlob: Data
+        public let comment: Data
 
-        public var errorDescription: String? {
-            switch self {
-            case .unsupportedType:
-                return "The key type was unsupported"
-            case .parsingFailed:
-                return "Failed to properly parse the SSH certificate"
-            case .doesNotExist:
-                return "Certificate does not exist"
-            }
+        init(keyBlob: Data, comment: Data) {
+            self.keyBlob = keyBlob
+            self.comment = comment
         }
     }
 

--- a/Sources/Packages/Sources/SecretAgentKit/PublicKeyStandinFileController.swift
+++ b/Sources/Packages/Sources/SecretAgentKit/PublicKeyStandinFileController.swift
@@ -10,6 +10,8 @@ public final class PublicKeyFileStoreController: Sendable {
     private let logger = Logger(subsystem: "com.maxgoedjen.secretive.secretagent", category: "PublicKeyFileStoreController")
     private let directory: URL
     private let keyWriter = OpenSSHPublicKeyWriter()
+    private let publicKeyReader = OpenSSHPublicKeyReader()
+    private let certificateReader = OpenSSHCertificateReader()
 
     /// Initializes a PublicKeyFileStoreController.
     public init(directory: URL) {
@@ -21,48 +23,122 @@ public final class PublicKeyFileStoreController: Sendable {
     /// - Parameter clear: Whether or not any untracked files in the directory should be removed.
     public func generatePublicKeys(for secrets: [AnySecret], clear: Bool = false) throws {
         logger.log("Writing public keys to disk")
-        if clear {
-            let validPaths = Set(secrets.map { URL.publicKeyPath(for: $0, in: directory) })
-                .union(Set(secrets.map { sshCertificatePath(for: $0) }))
-            let contentsOfDirectory = (try? FileManager.default.contentsOfDirectory(atPath: directory.path())) ?? []
-            let fullPathContents = contentsOfDirectory.map { directory.appending(path: $0).path() }
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true, attributes: nil)
+        let trackedPublicKeyFilenames = Set(secrets.map(generatedPublicKeyFilename(for:)))
 
-            let untracked = Set(fullPathContents)
-                .subtracting(validPaths)
-            for path in untracked {
-                // string instead of fileURLWithPath since we're already using fileURL format.
-                try? FileManager.default.removeItem(at: URL(string: path)!)
-            }
-        }
-        try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: false, attributes: nil)
         for secret in secrets {
             let path = URL.publicKeyPath(for: secret, in: directory)
             let data = Data(keyWriter.openSSHString(secret: secret).utf8)
-            FileManager.default.createFile(atPath: path, contents: data, attributes: nil)
+            try data.write(to: URL(fileURLWithPath: path), options: .atomic)
+        }
+
+        removeLegacyManifestIfNeeded()
+        if clear {
+            try pruneManagedArtifacts(trackedPublicKeyFilenames: trackedPublicKeyFilenames)
         }
         logger.log("Finished writing public keys")
     }
 
+}
 
-    /// Short-circuit check to ship enumerating a bunch of paths if there's nothing in the cert directory.
-    public var hasAnyCertificates: Bool {
-        do {
-            return try FileManager.default
-                .contentsOfDirectory(atPath: directory.path())
-                .filter { $0.hasSuffix("-cert.pub") }
-                .isEmpty == false
-        } catch {
-            return false
+extension PublicKeyFileStoreController {
+    private static let legacyManifestFilename = ".secretive-generated-public-keys"
+
+    private func generatedPublicKeyFilename(for secret: AnySecret) -> String {
+        URL(fileURLWithPath: URL.publicKeyPath(for: secret, in: directory)).lastPathComponent
+    }
+
+    private func pruneManagedArtifacts(trackedPublicKeyFilenames: Set<String>) throws {
+        let fileURLs = try FileManager.default
+            .contentsOfDirectory(at: directory, includingPropertiesForKeys: [.isRegularFileKey], options: [.skipsHiddenFiles])
+            .sorted { $0.lastPathComponent < $1.lastPathComponent }
+
+        var activeKeysByFingerprint: [String: URL] = [:]
+        var activeCertificatesByFingerprint: [String: [URL]] = [:]
+
+        for fileURL in fileURLs {
+            let values = try fileURL.resourceValues(forKeys: [.isRegularFileKey])
+            guard values.isRegularFile == true else {
+                continue
+            }
+
+            guard let contents = try? String(contentsOf: fileURL, encoding: .utf8) else {
+                logger.warning("Failed to read public key artifact at \(fileURL.lastPathComponent, privacy: .public)")
+                continue
+            }
+
+            if let parsedPublicKey = parsedPublicKey(from: contents) {
+                if trackedPublicKeyFilenames.contains(fileURL.lastPathComponent) {
+                    activeKeysByFingerprint[parsedPublicKey.fingerprint] = fileURL
+                } else {
+                    removeItemIfNeeded(
+                        at: fileURL,
+                        successMessage: "Removed stale generated public key at \(fileURL.lastPathComponent)",
+                        failureMessage: "Failed to remove stale generated public key at \(fileURL.lastPathComponent)"
+                    )
+                }
+                continue
+            }
+
+            guard let parsedCertificate = parsedCertificate(from: contents) else {
+                continue
+            }
+
+            if parsedCertificate.isExpired() {
+                removeItemIfNeeded(
+                    at: fileURL,
+                    successMessage: "Removed expired certificate at \(fileURL.lastPathComponent)",
+                    failureMessage: "Failed to remove expired certificate at \(fileURL.lastPathComponent)"
+                )
+                continue
+            }
+
+            activeCertificatesByFingerprint[parsedCertificate.subjectKeyFingerprint, default: []].append(fileURL)
+        }
+
+        for (fingerprint, certificateURLs) in activeCertificatesByFingerprint where activeKeysByFingerprint[fingerprint] == nil {
+            for certificateURL in certificateURLs {
+                removeItemIfNeeded(
+                    at: certificateURL,
+                    successMessage: "Removed orphaned certificate at \(certificateURL.lastPathComponent)",
+                    failureMessage: "Failed to remove orphaned certificate at \(certificateURL.lastPathComponent)"
+                )
+            }
         }
     }
 
-    /// The path for a Secret's SSH Certificate public key.
-    /// - Parameter secret: The Secret to return the path for.
-    /// - Returns: The path to the SSH Certificate public key.
-    /// - Warning: This method returning a path does not imply that a key has a SSH certificates. This method only describes where it will be.
-    public func sshCertificatePath<SecretType: Secret>(for secret: SecretType) -> String {
-        let minimalHex = keyWriter.openSSHMD5Fingerprint(secret: secret).replacingOccurrences(of: ":", with: "")
-        return directory.appending(component: "\(minimalHex)-cert.pub").path()
+    private func parsedPublicKey(from contents: String) -> OpenSSHPublicKeyReader.ParsedPublicKey? {
+        try? publicKeyReader.readPublicKeyLine(contents)
+    }
+
+    private func parsedCertificate(from contents: String) -> OpenSSHCertificateReader.ParsedCertificate? {
+        try? certificateReader.readPublicKeyLine(contents)
+    }
+
+    private func removeLegacyManifestIfNeeded() {
+        let manifestURL = directory.appending(path: Self.legacyManifestFilename)
+        guard FileManager.default.fileExists(atPath: manifestURL.path()) else {
+            return
+        }
+
+        removeItemIfNeeded(
+            at: manifestURL,
+            successMessage: "Removed legacy generated public key manifest",
+            failureMessage: "Failed to remove legacy generated public key manifest"
+        )
+    }
+
+    private func removeItemIfNeeded(at fileURL: URL, successMessage: String, failureMessage: String) {
+        guard FileManager.default.fileExists(atPath: fileURL.path()) else {
+            return
+        }
+
+        do {
+            try FileManager.default.removeItem(at: fileURL)
+            logger.log("\(successMessage, privacy: .public)")
+        } catch {
+            logger.warning("\(failureMessage, privacy: .public)")
+        }
     }
 
 }

--- a/Sources/Packages/Sources/SecretAgentKit/SSHAgentInputParser.swift
+++ b/Sources/Packages/Sources/SecretAgentKit/SSHAgentInputParser.swift
@@ -12,6 +12,7 @@ public protocol SSHAgentInputParserProtocol {
 public struct SSHAgentInputParser: SSHAgentInputParserProtocol {
 
     private let logger = Logger(subsystem: "com.maxgoedjen.secretive.secretagent", category: "InputParser")
+    private let certificateReader = OpenSSHCertificateReader()
 
     public init() {
 
@@ -73,26 +74,7 @@ extension SSHAgentInputParser {
     }
 
     func certificatePublicKeyBlob(from hash: Data) -> Data? {
-        let reader = OpenSSHReader(data: hash)
-        do {
-            let certType = String(decoding: try reader.readNextChunk(), as: UTF8.self)
-            switch certType {
-            case "ecdsa-sha2-nistp256-cert-v01@openssh.com",
-                "ecdsa-sha2-nistp384-cert-v01@openssh.com",
-                "ecdsa-sha2-nistp521-cert-v01@openssh.com":
-                _ = try reader.readNextChunk() // nonce
-                let curveIdentifier = try reader.readNextChunk()
-                let publicKey = try reader.readNextChunk()
-                let openSSHIdentifier = certType.replacingOccurrences(of: "-cert-v01@openssh.com", with: "")
-                return openSSHIdentifier.lengthAndData +
-                curveIdentifier.lengthAndData +
-                publicKey.lengthAndData
-            default:
-                return nil
-            }
-        } catch {
-            return nil
-        }
+        try? certificateReader.readCertificateBlob(hash).subjectKeyBlob
     }
 
 }

--- a/Sources/Packages/Sources/XPCWrappers/TeamID.swift
+++ b/Sources/Packages/Sources/XPCWrappers/TeamID.swift
@@ -1,26 +1,67 @@
 import Foundation
 
 extension ProcessInfo {
-    private static let fallbackTeamID = "Z72PRUAWF6"
-
     private static let teamID: String = {
-        #if DEBUG
-        guard let task = SecTaskCreateFromSelf(nil) else {
-            assertionFailure("SecTaskCreateFromSelf failed")
-            return fallbackTeamID
-        }
-
-        guard let value = SecTaskCopyValueForEntitlement(task, "com.apple.developer.team-identifier" as CFString, nil) as? String else {
-            assertionFailure("SecTaskCopyValueForEntitlement(com.apple.developer.team-identifier) failed")
-            return fallbackTeamID
-        }
-
-        return value
-        #else
-        /// Always use hardcoded team ID for release builds, just in case.
-        return fallbackTeamID
-        #endif
+        TeamIDResolver.resolve(
+            entitlementTeamID: TeamIDResolver.currentEntitlementTeamID(),
+            configuredFallbackTeamID: TeamIDResolver.configuredFallbackTeamID(in: Bundle.main.infoDictionary)
+        )
     }()
 
     public var teamID: String { Self.teamID }
+}
+
+enum TeamIDResolver {
+    static let infoDictionaryKey = "SecretiveDevelopmentTeam"
+
+    static func currentEntitlementTeamID() -> String? {
+        guard let task = SecTaskCreateFromSelf(nil) else {
+            assertionFailure("SecTaskCreateFromSelf failed")
+            return nil
+        }
+
+        guard let entitlementTeamID = SecTaskCopyValueForEntitlement(
+            task,
+            "com.apple.developer.team-identifier" as CFString,
+            nil
+        ) as? String else {
+            assertionFailure("SecTaskCopyValueForEntitlement(com.apple.developer.team-identifier) failed")
+            return nil
+        }
+
+        return normalizedTeamID(entitlementTeamID)
+    }
+
+    static func configuredFallbackTeamID(in infoDictionary: [String: Any]?) -> String? {
+        guard let configuredFallbackTeamID = infoDictionary?[infoDictionaryKey] as? String else {
+            return nil
+        }
+
+        return normalizedTeamID(configuredFallbackTeamID)
+    }
+
+    static func resolve(entitlementTeamID: String?, configuredFallbackTeamID: String?) -> String {
+        if let entitlementTeamID = normalizedTeamID(entitlementTeamID) {
+            return entitlementTeamID
+        }
+
+        if let configuredFallbackTeamID {
+            return configuredFallbackTeamID
+        }
+
+        preconditionFailure("Expected either an entitlement team ID or a configured fallback team ID.")
+    }
+
+    private static func normalizedTeamID(_ teamID: String?) -> String? {
+        guard let teamID else {
+            return nil
+        }
+
+        let trimmedTeamID = teamID.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedTeamID.isEmpty else {
+            return nil
+        }
+
+        return trimmedTeamID
+    }
 }

--- a/Sources/Packages/Tests/CommonTests/BundleIDTests.swift
+++ b/Sources/Packages/Tests/CommonTests/BundleIDTests.swift
@@ -1,0 +1,35 @@
+import XCTest
+@testable import Common
+
+final class BundleIDTests: XCTestCase {
+
+    func testReplacingLastBundleComponentRewritesHostBundleIDs() {
+        XCTAssertEqual(
+            Bundle.replacingLastBundleComponent(
+                in: "2DC432GLL2.com.example.Secretive.Host",
+                with: "SecretAgent"
+            ),
+            "2DC432GLL2.com.example.Secretive.SecretAgent"
+        )
+    }
+
+    func testReplacingLastBundleComponentRewritesAgentBundleIDsForXPCServices() {
+        XCTAssertEqual(
+            Bundle.replacingLastBundleComponent(
+                in: "2DC432GLL2.com.example.Secretive.SecretAgent",
+                with: "SecretAgentInputParser"
+            ),
+            "2DC432GLL2.com.example.Secretive.SecretAgentInputParser"
+        )
+    }
+
+    func testReplacingLastBundleComponentRewritesBetweenXPCServices() {
+        XCTAssertEqual(
+            Bundle.replacingLastBundleComponent(
+                in: "2DC432GLL2.com.example.Secretive.SecretiveUpdater",
+                with: "SecretAgentInputParser"
+            ),
+            "2DC432GLL2.com.example.Secretive.SecretAgentInputParser"
+        )
+    }
+}

--- a/Sources/Packages/Tests/SSHProtocolKitTests/OpenSSHCertificateReaderTests.swift
+++ b/Sources/Packages/Tests/SSHProtocolKitTests/OpenSSHCertificateReaderTests.swift
@@ -1,0 +1,135 @@
+import Foundation
+import Testing
+@testable import SecretKit
+import SSHProtocolKit
+
+@Suite struct OpenSSHCertificateReaderTests {
+
+    let writer = OpenSSHPublicKeyWriter()
+    let certificateReader = OpenSSHCertificateReader()
+
+    @Test func readPublicKeyLinePreservesFullCommentAndFingerprint() throws {
+        let certificateBlob = certificateBlob(
+            for: Constants.ecdsa256Secret,
+            validAfter: 42,
+            validBefore: 4_102_444_800
+        )
+        let line = [
+            Constants.ecdsa256CertificateType,
+            certificateBlob.base64EncodedString(),
+            "deploy cert for production west"
+        ].joined(separator: " ")
+
+        let parsed = try certificateReader.readPublicKeyLine(line)
+
+        #expect(parsed.type == Constants.ecdsa256CertificateType)
+        #expect(parsed.comment == "deploy cert for production west")
+        #expect(parsed.subjectKeyBlob == writer.data(secret: Constants.ecdsa256Secret))
+        #expect(parsed.subjectKeyFingerprint == writer.openSSHSHA256Fingerprint(secret: Constants.ecdsa256Secret))
+        #expect(parsed.validAfter == 42)
+        #expect(parsed.validBefore == 4_102_444_800)
+    }
+
+    @Test func readCertificateBlobExposesExpirationState() throws {
+        let expiredCertificate = try certificateReader.readCertificateBlob(
+            certificateBlob(
+                for: Constants.ecdsa256Secret,
+                validBefore: 1
+            )
+        )
+        let activeCertificate = try certificateReader.readCertificateBlob(
+            certificateBlob(
+                for: Constants.ecdsa256Secret,
+                validBefore: .max
+            )
+        )
+
+        #expect(expiredCertificate.isExpired(at: Date(timeIntervalSince1970: 2)))
+        #expect(!activeCertificate.isExpired(at: Date(timeIntervalSince1970: 2)))
+    }
+
+    @Test func readCertificateBlobRejectsBarePublicKey() throws {
+        do {
+            _ = try certificateReader.readCertificateBlob(writer.data(secret: Constants.ecdsa256Secret))
+            Issue.record("Expected bare public key to be rejected as a certificate")
+        } catch let error {
+            #expect(error == .unsupportedType)
+        }
+    }
+
+    @Test func readCertificateBlobRejectsTruncatedCertificate() throws {
+        let truncatedBlob = Constants.ecdsa256CertificateType.lengthAndData + Data("nonce".utf8).lengthAndData
+
+        do {
+            _ = try certificateReader.readCertificateBlob(truncatedBlob)
+            Issue.record("Expected truncated certificate blob to fail parsing")
+        } catch let error {
+            #expect(error == .parsingFailed)
+        }
+    }
+
+}
+
+extension OpenSSHCertificateReaderTests {
+
+    private func certificateBlob(
+        for secret: TestSecret,
+        type: String? = nil,
+        validAfter: UInt64 = 0,
+        validBefore: UInt64 = .max
+    ) -> Data {
+        let keyBlob = writer.data(secret: secret)
+        let reader = OpenSSHReader(data: keyBlob)
+        let certificateType = type ?? Constants.ecdsa256CertificateType
+
+        _ = try! reader.readNextChunkAsString()
+        let curveIdentifier = try! reader.readNextChunk()
+        let publicKey = try! reader.readNextChunk()
+
+        var certificateBlob = Data()
+        certificateBlob.append(certificateType.lengthAndData)
+        certificateBlob.append(Data("nonce".utf8).lengthAndData)
+        certificateBlob.append(curveIdentifier.lengthAndData)
+        certificateBlob.append(publicKey.lengthAndData)
+        certificateBlob.append(uint64Data(1))
+        certificateBlob.append(uint32Data(1))
+        certificateBlob.append("key-id".lengthAndData)
+        certificateBlob.append(Data().lengthAndData)
+        certificateBlob.append(uint64Data(validAfter))
+        certificateBlob.append(uint64Data(validBefore))
+        certificateBlob.append(Data().lengthAndData)
+        certificateBlob.append(Data().lengthAndData)
+        certificateBlob.append(Data().lengthAndData)
+        certificateBlob.append(keyBlob.lengthAndData)
+        certificateBlob.append(Data("signature".utf8).lengthAndData)
+        return certificateBlob
+    }
+
+    private func uint32Data(_ value: UInt32) -> Data {
+        Data([
+            UInt8((value >> 24) & 0xff),
+            UInt8((value >> 16) & 0xff),
+            UInt8((value >> 8) & 0xff),
+            UInt8(value & 0xff)
+        ])
+    }
+
+    private func uint64Data(_ value: UInt64) -> Data {
+        Data([
+            UInt8((value >> 56) & 0xff),
+            UInt8((value >> 48) & 0xff),
+            UInt8((value >> 40) & 0xff),
+            UInt8((value >> 32) & 0xff),
+            UInt8((value >> 24) & 0xff),
+            UInt8((value >> 16) & 0xff),
+            UInt8((value >> 8) & 0xff),
+            UInt8(value & 0xff)
+        ])
+    }
+
+    enum Constants {
+        static let ecdsa256CertificateType = "ecdsa-sha2-nistp256-cert-v01@openssh.com"
+        static let ecdsa256Secret = TestSecret(id: Data(), name: "Test Key (ECDSA 256)", publicKey: Data(base64Encoded: "BOVEjgAA5PHqRgwykjN5qM21uWCHFSY/Sqo5gkHAkn+e1MMQKHOLga7ucB9b3mif33MBid59GRK9GEPVlMiSQwo=")!, attributes: Attributes(keyType: KeyType(algorithm: .ecdsa, size: 256), authentication: .notRequired, publicKeyAttribution: "test@example.com"))
+    }
+
+}

--- a/Sources/Packages/Tests/SSHProtocolKitTests/OpenSSHPublicKeyReaderTests.swift
+++ b/Sources/Packages/Tests/SSHProtocolKitTests/OpenSSHPublicKeyReaderTests.swift
@@ -1,0 +1,99 @@
+import Foundation
+import Testing
+@testable import SecretKit
+import SSHProtocolKit
+
+@Suite struct OpenSSHPublicKeyReaderTests {
+
+    let reader = OpenSSHPublicKeyReader()
+    let writer = OpenSSHPublicKeyWriter()
+
+    @Test func readPublicKeyLinePreservesFullCommentAndFingerprint() throws {
+        let line = [
+            writer.openSSHIdentifier(for: Constants.ecdsa256Secret.keyType),
+            writer.data(secret: Constants.ecdsa256Secret).base64EncodedString(),
+            "deploy key for staging west"
+        ].joined(separator: " ")
+
+        let parsed = try reader.readPublicKeyLine(line)
+
+        #expect(parsed.type == writer.openSSHIdentifier(for: Constants.ecdsa256Secret.keyType))
+        #expect(parsed.comment == "deploy key for staging west")
+        #expect(parsed.keyBlob == writer.data(secret: Constants.ecdsa256Secret))
+        #expect(parsed.fingerprint == writer.openSSHSHA256Fingerprint(secret: Constants.ecdsa256Secret))
+    }
+
+    @Test func readPublicKeyLineRejectsCertificateLines() throws {
+        let line = [
+            Constants.ecdsa256CertificateType,
+            certificateBlob(for: Constants.ecdsa256Secret).base64EncodedString(),
+            "deploy cert"
+        ].joined(separator: " ")
+
+        do {
+            _ = try reader.readPublicKeyLine(line)
+            Issue.record("Expected certificate line to be rejected as a bare public key")
+        } catch let error {
+            #expect(error == .certificateType)
+        }
+    }
+
+}
+
+extension OpenSSHPublicKeyReaderTests {
+
+    private func certificateBlob(for secret: TestSecret) -> Data {
+        let keyBlob = writer.data(secret: secret)
+        let reader = OpenSSHReader(data: keyBlob)
+
+        _ = try! reader.readNextChunkAsString()
+        let curveIdentifier = try! reader.readNextChunk()
+        let publicKey = try! reader.readNextChunk()
+
+        var certificateBlob = Data()
+        certificateBlob.append(Constants.ecdsa256CertificateType.lengthAndData)
+        certificateBlob.append(Data("nonce".utf8).lengthAndData)
+        certificateBlob.append(curveIdentifier.lengthAndData)
+        certificateBlob.append(publicKey.lengthAndData)
+        certificateBlob.append(uint64Data(1))
+        certificateBlob.append(uint32Data(1))
+        certificateBlob.append("key-id".lengthAndData)
+        certificateBlob.append(Data().lengthAndData)
+        certificateBlob.append(uint64Data(0))
+        certificateBlob.append(uint64Data(.max))
+        certificateBlob.append(Data().lengthAndData)
+        certificateBlob.append(Data().lengthAndData)
+        certificateBlob.append(Data().lengthAndData)
+        certificateBlob.append(keyBlob.lengthAndData)
+        certificateBlob.append(Data("signature".utf8).lengthAndData)
+        return certificateBlob
+    }
+
+    private func uint32Data(_ value: UInt32) -> Data {
+        Data([
+            UInt8((value >> 24) & 0xff),
+            UInt8((value >> 16) & 0xff),
+            UInt8((value >> 8) & 0xff),
+            UInt8(value & 0xff)
+        ])
+    }
+
+    private func uint64Data(_ value: UInt64) -> Data {
+        Data([
+            UInt8((value >> 56) & 0xff),
+            UInt8((value >> 48) & 0xff),
+            UInt8((value >> 40) & 0xff),
+            UInt8((value >> 32) & 0xff),
+            UInt8((value >> 24) & 0xff),
+            UInt8((value >> 16) & 0xff),
+            UInt8((value >> 8) & 0xff),
+            UInt8(value & 0xff)
+        ])
+    }
+
+    enum Constants {
+        static let ecdsa256CertificateType = "ecdsa-sha2-nistp256-cert-v01@openssh.com"
+        static let ecdsa256Secret = TestSecret(id: Data(), name: "Test Key (ECDSA 256)", publicKey: Data(base64Encoded: "BOVEjgAA5PHqRgwykjN5qM21uWCHFSY/Sqo5gkHAkn+e1MMQKHOLga7ucB9b3mif33MBid59GRK9GEPVlMiSQwo=")!, attributes: Attributes(keyType: KeyType(algorithm: .ecdsa, size: 256), authentication: .notRequired, publicKeyAttribution: "test@example.com"))
+    }
+
+}

--- a/Sources/Packages/Tests/SecretAgentKitTests/AgentTests.swift
+++ b/Sources/Packages/Tests/SecretAgentKitTests/AgentTests.swift
@@ -28,6 +28,43 @@ import CryptoKit
         #expect(response == Constants.Responses.requestIdentitiesMultiple)
     }
 
+    @Test func identitiesListIncludesMultipleCertificatesForSingleKey() async throws {
+        let directory = try CertificateTestFixtures.temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        try CertificateTestFixtures.write(
+            CertificateTestFixtures.certificateLine(for: CertificateTestFixtures.ecdsa256Secret, comment: "Alpha cert"),
+            to: directory.appending(path: "first-access.pub")
+        )
+        try CertificateTestFixtures.write(
+            CertificateTestFixtures.certificateLine(for: CertificateTestFixtures.ecdsa256Secret, comment: "Beta cert"),
+            to: directory.appending(path: "second-access")
+        )
+
+        let list = await storeList(with: [CertificateTestFixtures.ecdsa256Secret])
+        let agent = Agent(storeList: list, certificateHandler: OpenSSHCertificateHandler(directory: directory))
+        let response = await agent.handle(request: .requestIdentities, provenance: .test)
+
+        let responseReader = OpenSSHReader(data: response)
+        let length = try responseReader.readNextBytes(as: UInt32.self)
+        let type = try responseReader.readNextBytes(as: UInt8.self)
+        #expect(length == response.count - MemoryLayout<UInt32>.size)
+        #expect(type == SSHAgent.Response.agentIdentitiesAnswer.rawValue)
+
+        let identitiesReader = OpenSSHReader(data: responseReader.remaining)
+        let count = try identitiesReader.readNextBytes(as: UInt32.self)
+        #expect(count == 3)
+
+        _ = try identitiesReader.readNextChunk()
+        _ = try identitiesReader.readNextChunkAsString()
+        _ = try identitiesReader.readNextChunk()
+        let firstComment = try identitiesReader.readNextChunkAsString()
+        _ = try identitiesReader.readNextChunk()
+        let secondComment = try identitiesReader.readNextChunkAsString()
+        #expect(firstComment == "Alpha cert")
+        #expect(secondComment == "Beta cert")
+    }
+
     // MARK: Signatures
 
     @Test func noMatchingIdentities() async throws {
@@ -68,6 +105,40 @@ import CryptoKit
         // Correct signature
         #expect(try P256.Signing.PublicKey(x963Representation: Constants.Secrets.ecdsa256Secret.publicKey)
             .isValidSignature(signature, for: context.dataToSign))
+    }
+
+    @Test func certificateSignRequestMatchesUnderlyingKey() async throws {
+        let certificateBlob = CertificateTestFixtures.certificateBlob(for: CertificateTestFixtures.ecdsa256Secret)
+        let dataToSign = Data("certificate signing payload".utf8)
+        let request = try SSHAgentInputParser().parse(data: CertificateTestFixtures.signRequest(for: certificateBlob, dataToSign: dataToSign))
+        guard case SSHAgent.Request.signRequest(let context) = request else { return }
+        #expect(context.keyBlob == OpenSSHPublicKeyWriter().data(secret: CertificateTestFixtures.ecdsa256Secret))
+
+        let list = await storeList(with: [CertificateTestFixtures.ecdsa256Secret])
+        let agent = Agent(storeList: list)
+        let response = await agent.handle(request: request, provenance: .test)
+        let responseReader = OpenSSHReader(data: response)
+        _ = try responseReader.readNextBytes(as: UInt32.self)
+        let type = try responseReader.readNextBytes(as: UInt8.self)
+        #expect(type == SSHAgent.Response.agentSignResponse.rawValue)
+
+        let outer = OpenSSHReader(data: responseReader.remaining)
+        let inner = try outer.readNextChunkAsSubReader()
+        _ = try inner.readNextChunk()
+        let rsData = try inner.readNextChunkAsSubReader()
+        var r = try rsData.readNextChunk()
+        var s = try rsData.readNextChunk()
+        if r[0] == 0 {
+            r.removeFirst()
+        }
+        if s[0] == 0 {
+            s.removeFirst()
+        }
+        var rs = r
+        rs.append(s)
+        let signature = try P256.Signing.ECDSASignature(rawRepresentation: rs)
+        #expect(try P256.Signing.PublicKey(x963Representation: CertificateTestFixtures.ecdsa256Secret.publicKey)
+            .isValidSignature(signature, for: dataToSign))
     }
 
     // MARK: Witness protocol

--- a/Sources/Packages/Tests/SecretAgentKitTests/CertificateTestFixtures.swift
+++ b/Sources/Packages/Tests/SecretAgentKitTests/CertificateTestFixtures.swift
@@ -1,0 +1,109 @@
+import Foundation
+import SecretKit
+import SSHProtocolKit
+
+enum CertificateTestFixtures {
+
+    static let writer = OpenSSHPublicKeyWriter()
+    static let ecdsa256CertificateType = "ecdsa-sha2-nistp256-cert-v01@openssh.com"
+    static let ecdsa256Secret = Stub.Secret(
+        keySize: 256,
+        publicKey: Data(base64Encoded: "BKzOkUiVJEcACMtAd9X7xalbc0FYZyhbmv2dsWl4IP2GWIi+RcsaHQNw+nAIQ8CKEYmLnl0VLDp5Ef8KMhgIy08=")!,
+        privateKey: Data(base64Encoded: "BKzOkUiVJEcACMtAd9X7xalbc0FYZyhbmv2dsWl4IP2GWIi+RcsaHQNw+nAIQ8CKEYmLnl0VLDp5Ef8KMhgIy09nw780wy/TSfUmzj15iJkV234AaCLNl+H8qFL6qK8VIg==")!
+    )
+    static let ecdsa384Secret = Stub.Secret(
+        keySize: 384,
+        publicKey: Data(base64Encoded: "BLKSzA5q3jCb3q0JKigvcxfWVGrJ+bklpG0Zc9YzUwrbsh9SipvlSJi+sHQI+O0m88DOpRBAtuAHX60euD/Yv250tovN7/+MEFbXGZ/hLdd0BoFpWbLfJcQj806KJGlcDA==")!,
+        privateKey: Data(base64Encoded: "BLKSzA5q3jCb3q0JKigvcxfWVGrJ+bklpG0Zc9YzUwrbsh9SipvlSJi+sHQI+O0m88DOpRBAtuAHX60euD/Yv250tovN7/+MEFbXGZ/hLdd0BoFpWbLfJcQj806KJGlcDHNapAOzrt9E+9QC4/KYoXS7Uw4pmdAz53uIj02tttiq3c0ZyIQ7XoscWWRqRrz8Kw==")!
+    )
+
+    static func certificateBlob(
+        for secret: Stub.Secret,
+        certificateType: String = ecdsa256CertificateType,
+        validAfter: UInt64 = 0,
+        validBefore: UInt64 = .max
+    ) -> Data {
+        let keyBlob = writer.data(secret: secret)
+        let reader = OpenSSHReader(data: keyBlob)
+        _ = try! reader.readNextChunkAsString()
+        let curveIdentifier = try! reader.readNextChunk()
+        let publicKey = try! reader.readNextChunk()
+
+        var certificateBlob = Data()
+        certificateBlob.append(certificateType.lengthAndData)
+        certificateBlob.append(Data("nonce".utf8).lengthAndData)
+        certificateBlob.append(curveIdentifier.lengthAndData)
+        certificateBlob.append(publicKey.lengthAndData)
+        certificateBlob.append(uint64Data(1))
+        certificateBlob.append(uint32Data(1))
+        certificateBlob.append("key-id".lengthAndData)
+        certificateBlob.append(Data().lengthAndData)
+        certificateBlob.append(uint64Data(validAfter))
+        certificateBlob.append(uint64Data(validBefore))
+        certificateBlob.append(Data().lengthAndData)
+        certificateBlob.append(Data().lengthAndData)
+        certificateBlob.append(Data().lengthAndData)
+        certificateBlob.append(keyBlob.lengthAndData)
+        certificateBlob.append(Data("signature".utf8).lengthAndData)
+        return certificateBlob
+    }
+
+    static func certificateLine(
+        for secret: Stub.Secret,
+        comment: String,
+        validAfter: UInt64 = 0,
+        validBefore: UInt64 = .max
+    ) -> String {
+        [
+            ecdsa256CertificateType,
+            certificateBlob(
+                for: secret,
+                validAfter: validAfter,
+                validBefore: validBefore
+            ).base64EncodedString(),
+            comment
+        ].joined(separator: " ")
+    }
+
+    static func signRequest(for keyBlob: Data, dataToSign: Data) -> Data {
+        let body = keyBlob.lengthAndData +
+        dataToSign.lengthAndData +
+        uint32Data(0)
+        return uint32Data(UInt32(body.count + 1)) +
+        Data([SSHAgent.Request.signRequest(.empty).protocolID]) +
+        body
+    }
+
+    static func temporaryDirectory() throws -> URL {
+        let directory = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString, directoryHint: .isDirectory)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        return directory
+    }
+
+    static func write(_ contents: String, to fileURL: URL) throws {
+        try Data(contents.utf8).write(to: fileURL, options: .atomic)
+    }
+
+    static func uint32Data(_ value: UInt32) -> Data {
+        Data([
+            UInt8((value >> 24) & 0xff),
+            UInt8((value >> 16) & 0xff),
+            UInt8((value >> 8) & 0xff),
+            UInt8(value & 0xff)
+        ])
+    }
+
+    static func uint64Data(_ value: UInt64) -> Data {
+        Data([
+            UInt8((value >> 56) & 0xff),
+            UInt8((value >> 48) & 0xff),
+            UInt8((value >> 40) & 0xff),
+            UInt8((value >> 32) & 0xff),
+            UInt8((value >> 24) & 0xff),
+            UInt8((value >> 16) & 0xff),
+            UInt8((value >> 8) & 0xff),
+            UInt8(value & 0xff)
+        ])
+    }
+
+}

--- a/Sources/Packages/Tests/SecretAgentKitTests/OpenSSHCertificateHandlerTests.swift
+++ b/Sources/Packages/Tests/SecretAgentKitTests/OpenSSHCertificateHandlerTests.swift
@@ -1,0 +1,76 @@
+import Foundation
+import Testing
+import SSHProtocolKit
+@testable import SecretAgentKit
+
+@Suite struct OpenSSHCertificateHandlerTests {
+
+    @Test func multipleCertificatesForSingleSecretAreEnumeratedInStableOrder() async throws {
+        let directory = try CertificateTestFixtures.temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        try CertificateTestFixtures.write(
+            CertificateTestFixtures.certificateLine(for: CertificateTestFixtures.ecdsa256Secret, comment: "Alpha cert"),
+            to: directory.appending(path: "alpha-access")
+        )
+        try CertificateTestFixtures.write(
+            CertificateTestFixtures.certificateLine(for: CertificateTestFixtures.ecdsa256Secret, comment: "Beta cert with spaces"),
+            to: directory.appending(path: "omega-access.pub")
+        )
+        try CertificateTestFixtures.write(
+            CertificateTestFixtures.writer.openSSHString(secret: CertificateTestFixtures.ecdsa256Secret),
+            to: directory.appending(path: "plain-key.pub")
+        )
+
+        let handler = OpenSSHCertificateHandler(directory: directory)
+        await handler.reloadCertificates()
+        let identities = await handler.certificateIdentities(for: CertificateTestFixtures.ecdsa256Secret)
+        let certificateReader = OpenSSHCertificateReader()
+        let expectedFingerprint = CertificateTestFixtures.writer.openSSHSHA256Fingerprint(secret: CertificateTestFixtures.ecdsa256Secret)
+
+        #expect(identities.count == 2)
+        #expect(String(decoding: identities[0].comment, as: UTF8.self) == "Alpha cert")
+        #expect(String(decoding: identities[1].comment, as: UTF8.self) == "Beta cert with spaces")
+        #expect(try identities.allSatisfy { try certificateReader.readCertificateBlob($0.keyBlob).subjectKeyFingerprint == expectedFingerprint })
+    }
+
+    @Test func certificateFilesAreMatchedByEmbeddedFingerprintNotFilename() async throws {
+        let directory = try CertificateTestFixtures.temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        try CertificateTestFixtures.write(
+            CertificateTestFixtures.certificateLine(for: CertificateTestFixtures.ecdsa256Secret, comment: "Primary cert"),
+            to: directory.appending(path: "looks-like-secondary.pub")
+        )
+
+        let handler = OpenSSHCertificateHandler(directory: directory)
+        await handler.reloadCertificates()
+
+        let primaryIdentities = await handler.certificateIdentities(for: CertificateTestFixtures.ecdsa256Secret)
+        let secondaryIdentities = await handler.certificateIdentities(for: CertificateTestFixtures.ecdsa384Secret)
+
+        #expect(primaryIdentities.count == 1)
+        #expect(secondaryIdentities.isEmpty)
+    }
+
+    @Test func certificateCacheClearsWhenFilesDisappear() async throws {
+        let directory = try CertificateTestFixtures.temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let certificateURL = directory.appending(path: "temporary-cert.pub")
+        try CertificateTestFixtures.write(
+            CertificateTestFixtures.certificateLine(for: CertificateTestFixtures.ecdsa256Secret, comment: "Ephemeral cert"),
+            to: certificateURL
+        )
+
+        let handler = OpenSSHCertificateHandler(directory: directory)
+        await handler.reloadCertificates()
+        #expect(await handler.certificateIdentities(for: CertificateTestFixtures.ecdsa256Secret).count == 1)
+
+        try FileManager.default.removeItem(at: certificateURL)
+        await handler.reloadCertificates()
+
+        #expect(await handler.certificateIdentities(for: CertificateTestFixtures.ecdsa256Secret).isEmpty)
+    }
+
+}

--- a/Sources/Packages/Tests/SecretAgentKitTests/PublicKeyFileStoreControllerTests.swift
+++ b/Sources/Packages/Tests/SecretAgentKitTests/PublicKeyFileStoreControllerTests.swift
@@ -1,0 +1,96 @@
+import Foundation
+import Testing
+import SecretKit
+@testable import SecretAgentKit
+import Common
+
+@Suite struct PublicKeyFileStoreControllerTests {
+
+    @Test func clearGeneratedPublicKeysRemovesExpiredCertificates() throws {
+        let directory = try CertificateTestFixtures.temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let controller = PublicKeyFileStoreController(directory: directory)
+        let activeSecret = AnySecret(CertificateTestFixtures.ecdsa256Secret)
+        let expiredCertificateURL = directory.appending(path: "expired-access-cert.pub")
+
+        try controller.generatePublicKeys(for: [activeSecret], clear: false)
+        try CertificateTestFixtures.write(
+            CertificateTestFixtures.certificateLine(
+                for: CertificateTestFixtures.ecdsa256Secret,
+                comment: "Expired certificate",
+                validBefore: 1
+            ),
+            to: expiredCertificateURL
+        )
+
+        try controller.generatePublicKeys(for: [activeSecret], clear: true)
+
+        #expect(!FileManager.default.fileExists(atPath: expiredCertificateURL.path()))
+    }
+
+    @Test func clearGeneratedPublicKeysRemovesCertificatesForMissingKeys() throws {
+        let directory = try CertificateTestFixtures.temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let controller = PublicKeyFileStoreController(directory: directory)
+        let activeSecret = AnySecret(CertificateTestFixtures.ecdsa256Secret)
+        let orphanedCertificateURL = directory.appending(path: "orphaned-access-cert.pub")
+
+        try controller.generatePublicKeys(for: [activeSecret], clear: false)
+        try CertificateTestFixtures.write(
+            CertificateTestFixtures.certificateLine(
+                for: CertificateTestFixtures.ecdsa384Secret,
+                comment: "Orphaned certificate",
+                validBefore: 4_102_444_800
+            ),
+            to: orphanedCertificateURL
+        )
+
+        try controller.generatePublicKeys(for: [activeSecret], clear: true)
+
+        #expect(!FileManager.default.fileExists(atPath: orphanedCertificateURL.path()))
+    }
+
+    @Test func clearGeneratedPublicKeysKeepsNonExpiredCertificatesForActiveKeys() throws {
+        let directory = try CertificateTestFixtures.temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let controller = PublicKeyFileStoreController(directory: directory)
+        let activeSecret = AnySecret(CertificateTestFixtures.ecdsa256Secret)
+        let activeCertificateURL = directory.appending(path: "active-access-cert.pub")
+
+        try controller.generatePublicKeys(for: [activeSecret], clear: false)
+        try CertificateTestFixtures.write(
+            CertificateTestFixtures.certificateLine(
+                for: CertificateTestFixtures.ecdsa256Secret,
+                comment: "Active certificate",
+                validBefore: 4_102_444_800
+            ),
+            to: activeCertificateURL
+        )
+
+        try controller.generatePublicKeys(for: [activeSecret], clear: true)
+
+        #expect(FileManager.default.fileExists(atPath: URL.publicKeyPath(for: activeSecret, in: directory)))
+        #expect(FileManager.default.fileExists(atPath: activeCertificateURL.path()))
+    }
+
+    @Test func clearGeneratedPublicKeysRemovesStaleGeneratedPublicKeys() throws {
+        let directory = try CertificateTestFixtures.temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let controller = PublicKeyFileStoreController(directory: directory)
+        let originalSecret = AnySecret(CertificateTestFixtures.ecdsa256Secret)
+        let replacementSecret = AnySecret(CertificateTestFixtures.ecdsa384Secret)
+        let originalPath = URL.publicKeyPath(for: originalSecret, in: directory)
+        let replacementPath = URL.publicKeyPath(for: replacementSecret, in: directory)
+
+        try controller.generatePublicKeys(for: [originalSecret], clear: false)
+        try controller.generatePublicKeys(for: [replacementSecret], clear: true)
+
+        #expect(!FileManager.default.fileExists(atPath: originalPath))
+        #expect(FileManager.default.fileExists(atPath: replacementPath))
+    }
+
+}

--- a/Sources/Packages/Tests/XPCWrappersTests/TeamIDTests.swift
+++ b/Sources/Packages/Tests/XPCWrappersTests/TeamIDTests.swift
@@ -1,0 +1,32 @@
+import Testing
+@testable import XPCWrappers
+
+@Suite struct TeamIDTests {
+
+    @Test func resolvePrefersEntitlementTeamIDOverConfiguredFallback() {
+        #expect(
+            TeamIDResolver.resolve(
+                entitlementTeamID: "ACTUALTEAM",
+                configuredFallbackTeamID: "CONFIGTEAM"
+            ) == "ACTUALTEAM"
+        )
+    }
+
+    @Test func resolveFallsBackToConfiguredTeamIDWhenEntitlementIsMissing() {
+        #expect(
+            TeamIDResolver.resolve(
+                entitlementTeamID: nil,
+                configuredFallbackTeamID: "CONFIGTEAM"
+            ) == "CONFIGTEAM"
+        )
+    }
+
+    @Test func configuredFallbackTeamIDReadsInfoDictionaryValue() {
+        #expect(
+            TeamIDResolver.configuredFallbackTeamID(
+                in: [TeamIDResolver.infoDictionaryKey: "CONFIGTEAM"]
+            ) == "CONFIGTEAM"
+        )
+    }
+
+}

--- a/Sources/SecretAgent/Info.plist
+++ b/Sources/SecretAgent/Info.plist
@@ -26,6 +26,8 @@
 	<true/>
 	<key>NSHumanReadableCopyright</key>
 	<string>$(PRODUCT_NAME) is MIT Licensed.</string>
+	<key>SecretiveDevelopmentTeam</key>
+	<string>$(SECRETIVE_DEVELOPMENT_TEAM)</string>
 	<key>NSMainStoryboardFile</key>
 	<string>Main</string>
 	<key>NSPrincipalClass</key>

--- a/Sources/SecretAgent/XPCInputParser.swift
+++ b/Sources/SecretAgent/XPCInputParser.swift
@@ -4,6 +4,7 @@ import Brief
 import XPCWrappers
 import OSLog
 import SSHProtocolKit
+import Common
 
 /// Delegates all agent input parsing to an XPC service which wraps OpenSSH
 public final class XPCAgentInputParser: SSHAgentInputParserProtocol {
@@ -13,7 +14,7 @@ public final class XPCAgentInputParser: SSHAgentInputParserProtocol {
 
     public init() async throws {
         logger.debug("Creating XPCAgentInputParser")
-        session = try await XPCTypedSession(serviceName: "com.maxgoedjen.Secretive.SecretAgentInputParser", warmup: true)
+        session = try await XPCTypedSession(serviceName: Bundle.secretAgentInputParserServiceBundleID, warmup: true)
         logger.debug("XPCAgentInputParser is warmed up.")
     }
 

--- a/Sources/SecretAgentInputParser/Info.plist
+++ b/Sources/SecretAgentInputParser/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>SecretiveDevelopmentTeam</key>
+	<string>$(SECRETIVE_DEVELOPMENT_TEAM)</string>
 	<key>XPCService</key>
 	<dict>
 		<key>ServiceType</key>

--- a/Sources/Secretive/Info.plist
+++ b/Sources/Secretive/Info.plist
@@ -26,6 +26,8 @@
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>$(PRODUCT_NAME) is MIT Licensed.</string>
+	<key>SecretiveDevelopmentTeam</key>
+	<string>$(SECRETIVE_DEVELOPMENT_TEAM)</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
 	<key>NSSupportsAutomaticTermination</key>

--- a/Sources/SecretiveUpdater/Info.plist
+++ b/Sources/SecretiveUpdater/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>SecretiveDevelopmentTeam</key>
+	<string>$(SECRETIVE_DEVELOPMENT_TEAM)</string>
 	<key>XPCService</key>
 	<dict>
 		<key>ServiceType</key>


### PR DESCRIPTION
This does not address UI, but does enable support for multiple certificates per key by moving to fingerprint matching and away from hardcoded 1:1 assumptions.

Addresses: https://github.com/maxgoedjen/secretive/issues/791

<img width="900" height="130" alt="image" src="https://github.com/user-attachments/assets/1567ef97-3974-429a-bcb3-8641ab5aa50a" />
