### PR TITLE
feat: add Secretive CLI management commands

### DIFF
--- a/Sources/Packages/Sources/SecretKit/CLI/SecretiveCLI.swift
+++ b/Sources/Packages/Sources/SecretKit/CLI/SecretiveCLI.swift
@@ -4,11 +4,14 @@ public enum SecretiveCLIInvocation: Sendable, Equatable {
     case none
     case help
     case createSecret(CreateSecret)
+    case listSecrets
     case installAgent
     case uninstallAgent
     case agentStatus
     case socketPath
     case printIntegration(PrintIntegration)
+    case publicKeyPath(SecretSelector)
+    case exportPublicKey(SecretSelector)
 
     public static func parse(arguments: [String]) throws -> Self {
         let filtered = arguments.filter { !$0.hasPrefix("-psn_") }
@@ -21,16 +24,27 @@ public enum SecretiveCLIInvocation: Sendable, Equatable {
             return .help
         case "create-secret":
             return .createSecret(try CreateSecret.parse(arguments: Array(filtered.dropFirst())))
+        case "list-secrets":
+            try validateNoArguments(arguments: Array(filtered.dropFirst()))
+            return .listSecrets
         case "install-agent":
+            try validateNoArguments(arguments: Array(filtered.dropFirst()))
             return .installAgent
         case "uninstall-agent":
+            try validateNoArguments(arguments: Array(filtered.dropFirst()))
             return .uninstallAgent
         case "agent-status":
+            try validateNoArguments(arguments: Array(filtered.dropFirst()))
             return .agentStatus
         case "socket-path":
+            try validateNoArguments(arguments: Array(filtered.dropFirst()))
             return .socketPath
         case "print-integration":
             return .printIntegration(try PrintIntegration.parse(arguments: Array(filtered.dropFirst())))
+        case "public-key-path":
+            return .publicKeyPath(try SecretSelector.parse(arguments: Array(filtered.dropFirst())))
+        case "export-public-key":
+            return .exportPublicKey(try SecretSelector.parse(arguments: Array(filtered.dropFirst())))
         default:
             return .none
         }
@@ -40,11 +54,14 @@ public enum SecretiveCLIInvocation: Sendable, Equatable {
         """
         Usage:
           Secretive create-secret --name <name> [--protection-level <1|2|3>] [--key-type <\(CreateSecret.supportedKeyTypes.map(\.description).joined(separator: "|"))>] [--key-attribution <value>]
+          Secretive list-secrets
           Secretive install-agent
           Secretive uninstall-agent
           Secretive agent-status
           Secretive socket-path
           Secretive print-integration --tool <\(PrintIntegration.Tool.allCases.map(\.rawValue).joined(separator: "|"))>
+          Secretive public-key-path (--id <id> | --name <name>)
+          Secretive export-public-key (--id <id> | --name <name>)
 
         Protection levels:
           1  require authentication
@@ -62,6 +79,17 @@ public enum SecretiveCLIInvocation: Sendable, Equatable {
           key-type: ecdsa-256
           key-attribution: omitted
         """
+    }
+
+    private static func validateNoArguments(arguments: [String]) throws {
+        for argument in arguments {
+            switch argument {
+            case "--help", "-h":
+                throw ParseError.helpRequested
+            default:
+                throw ParseError.unexpectedArgument(argument)
+            }
+        }
     }
 
     public struct CreateSecret: Sendable, Equatable {
@@ -179,6 +207,8 @@ public enum SecretiveCLIInvocation: Sendable, Equatable {
         case helpRequested
         case missingValue(String)
         case missingRequiredOption(String)
+        case missingSecretSelector
+        case conflictingOptions(String, String)
         case emptyValue(String)
         case invalidProtectionLevel(String)
         case invalidKeyType(String)
@@ -195,6 +225,10 @@ public enum SecretiveCLIInvocation: Sendable, Equatable {
                 return "Missing value for \(option)."
             case let .missingRequiredOption(option):
                 return "Missing required option \(option)."
+            case .missingSecretSelector:
+                return "Specify exactly one of --id or --name."
+            case let .conflictingOptions(first, second):
+                return "Options \(first) and \(second) cannot be used together."
             case let .emptyValue(option):
                 return "Option \(option) cannot be empty."
             case let .invalidProtectionLevel(value):
@@ -245,6 +279,54 @@ public enum SecretiveCLIInvocation: Sendable, Equatable {
             case zsh
             case bash
             case fish
+        }
+    }
+
+    public struct SecretSelector: Sendable, Equatable {
+        public let id: String?
+        public let name: String?
+
+        static func parse(arguments: [String]) throws -> Self {
+            var id: String?
+            var name: String?
+
+            var index = 0
+            while index < arguments.count {
+                let argument = arguments[index]
+                switch argument {
+                case "--help", "-h":
+                    throw ParseError.helpRequested
+                case "--id":
+                    if name != nil {
+                        throw ParseError.conflictingOptions("--id", "--name")
+                    }
+                    let rawValue = try CreateSecret.value(after: argument, arguments: arguments, index: &index)
+                    let trimmedValue = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+                    guard !trimmedValue.isEmpty else {
+                        throw ParseError.emptyValue("--id")
+                    }
+                    id = trimmedValue
+                case "--name":
+                    if id != nil {
+                        throw ParseError.conflictingOptions("--name", "--id")
+                    }
+                    let rawValue = try CreateSecret.value(after: argument, arguments: arguments, index: &index)
+                    let trimmedValue = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+                    guard !trimmedValue.isEmpty else {
+                        throw ParseError.emptyValue("--name")
+                    }
+                    name = trimmedValue
+                default:
+                    throw ParseError.unexpectedArgument(argument)
+                }
+                index += 1
+            }
+
+            guard id != nil || name != nil else {
+                throw ParseError.missingSecretSelector
+            }
+
+            return Self(id: id, name: name)
         }
     }
 }

--- a/Sources/Packages/Sources/SecretKit/CLI/SecretiveCLI.swift
+++ b/Sources/Packages/Sources/SecretKit/CLI/SecretiveCLI.swift
@@ -1,0 +1,197 @@
+import Foundation
+
+public enum SecretiveCLIInvocation: Sendable, Equatable {
+    case none
+    case help
+    case createSecret(CreateSecret)
+
+    public static func parse(arguments: [String]) throws -> Self {
+        let filtered = arguments.filter { !$0.hasPrefix("-psn_") }
+        guard let subcommand = filtered.first else {
+            return .none
+        }
+
+        switch subcommand {
+        case "help", "--help", "-h":
+            return .help
+        case "create-secret":
+            return .createSecret(try CreateSecret.parse(arguments: Array(filtered.dropFirst())))
+        default:
+            return .none
+        }
+    }
+
+    public static var usage: String {
+        """
+        Usage:
+          Secretive create-secret --name <name> [--protection-level <1|2|3>] [--key-type <\(CreateSecret.supportedKeyTypes.map(\.description).joined(separator: "|"))>] [--key-attribution <value>]
+
+        Protection levels:
+          1  require authentication
+          2  notification
+          3  current biometrics
+
+        Defaults:
+          protection-level: 1
+          key-type: ecdsa-256
+          key-attribution: omitted
+        """
+    }
+
+    public struct CreateSecret: Sendable, Equatable {
+        public let name: String
+        public let protectionLevel: ProtectionLevel
+        public let keyType: KeyType
+        public let keyAttribution: String?
+
+        public var attributes: Attributes {
+            Attributes(
+                keyType: keyType,
+                authentication: protectionLevel.authenticationRequirement,
+                publicKeyAttribution: keyAttribution
+            )
+        }
+
+        public static let supportedKeyTypes: [KeyType] = [
+            .ecdsa256,
+            .mldsa65,
+            .mldsa87,
+        ]
+
+        public static let defaultProtectionLevel: ProtectionLevel = .requireAuthentication
+        public static let defaultKeyType: KeyType = .ecdsa256
+
+        static func parse(arguments: [String]) throws -> Self {
+            var name: String?
+            var protectionLevel: ProtectionLevel?
+            var keyType: KeyType?
+            var keyAttribution: String?
+
+            var index = 0
+            while index < arguments.count {
+                let argument = arguments[index]
+                switch argument {
+                case "--help", "-h":
+                    throw ParseError.helpRequested
+                case "--name":
+                    name = try value(after: argument, arguments: arguments, index: &index)
+                case "--protection-level":
+                    let rawValue = try value(after: argument, arguments: arguments, index: &index)
+                    guard let parsedLevel = ProtectionLevel(rawValue: rawValue) else {
+                        throw ParseError.invalidProtectionLevel(rawValue)
+                    }
+                    protectionLevel = parsedLevel
+                case "--key-type":
+                    let rawValue = try value(after: argument, arguments: arguments, index: &index)
+                    guard let parsedType = KeyType(secretiveCLIValue: rawValue),
+                          supportedKeyTypes.contains(parsedType) else {
+                        throw ParseError.invalidKeyType(rawValue)
+                    }
+                    keyType = parsedType
+                case "--key-attribution":
+                    let rawValue = try value(after: argument, arguments: arguments, index: &index)
+                    keyAttribution = rawValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : rawValue
+                default:
+                    throw ParseError.unexpectedArgument(argument)
+                }
+                index += 1
+            }
+
+            guard let name else {
+                throw ParseError.missingRequiredOption("--name")
+            }
+            guard !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                throw ParseError.emptyValue("--name")
+            }
+            return Self(
+                name: name,
+                protectionLevel: protectionLevel ?? defaultProtectionLevel,
+                keyType: keyType ?? defaultKeyType,
+                keyAttribution: keyAttribution
+            )
+        }
+
+        private static func value(after option: String, arguments: [String], index: inout Int) throws -> String {
+            let valueIndex = index + 1
+            guard arguments.indices.contains(valueIndex) else {
+                throw ParseError.missingValue(option)
+            }
+            index = valueIndex
+            return arguments[valueIndex]
+        }
+    }
+
+    public enum ProtectionLevel: String, Sendable, Equatable, CaseIterable {
+        case requireAuthentication = "1"
+        case notification = "2"
+        case currentBiometrics = "3"
+
+        public var authenticationRequirement: AuthenticationRequirement {
+            switch self {
+            case .requireAuthentication:
+                .presenceRequired
+            case .notification:
+                .notRequired
+            case .currentBiometrics:
+                .biometryCurrent
+            }
+        }
+
+        public var summary: String {
+            switch self {
+            case .requireAuthentication:
+                "require authentication"
+            case .notification:
+                "notification"
+            case .currentBiometrics:
+                "current biometrics"
+            }
+        }
+    }
+
+    public enum ParseError: Error, LocalizedError, Equatable {
+        case helpRequested
+        case missingValue(String)
+        case missingRequiredOption(String)
+        case emptyValue(String)
+        case invalidProtectionLevel(String)
+        case invalidKeyType(String)
+        case unexpectedArgument(String)
+
+        public var errorDescription: String? {
+            let validKeyTypes = CreateSecret.supportedKeyTypes.map(\.description).joined(separator: ", ")
+            switch self {
+            case .helpRequested:
+                return SecretiveCLIInvocation.usage
+            case let .missingValue(option):
+                return "Missing value for \(option)."
+            case let .missingRequiredOption(option):
+                return "Missing required option \(option)."
+            case let .emptyValue(option):
+                return "Option \(option) cannot be empty."
+            case let .invalidProtectionLevel(value):
+                return "Invalid protection level '\(value)'. Valid values: 1, 2, 3."
+            case let .invalidKeyType(value):
+                return "Invalid key type '\(value)'. Valid values: \(validKeyTypes)."
+            case let .unexpectedArgument(argument):
+                return "Unexpected argument '\(argument)'."
+            }
+        }
+    }
+}
+
+public extension KeyType {
+    init?(secretiveCLIValue value: String) {
+        let normalized = value.lowercased().filter { !$0.isWhitespace && $0 != "-" && $0 != "_" }
+        switch normalized {
+        case "ecdsa256", "edcsa256":
+            self = .ecdsa256
+        case "mldsa65":
+            self = .mldsa65
+        case "mldsa87":
+            self = .mldsa87
+        default:
+            return nil
+        }
+    }
+}

--- a/Sources/Packages/Sources/SecretKit/CLI/SecretiveCLI.swift
+++ b/Sources/Packages/Sources/SecretKit/CLI/SecretiveCLI.swift
@@ -4,6 +4,11 @@ public enum SecretiveCLIInvocation: Sendable, Equatable {
     case none
     case help
     case createSecret(CreateSecret)
+    case installAgent
+    case uninstallAgent
+    case agentStatus
+    case socketPath
+    case printIntegration(PrintIntegration)
 
     public static func parse(arguments: [String]) throws -> Self {
         let filtered = arguments.filter { !$0.hasPrefix("-psn_") }
@@ -16,6 +21,16 @@ public enum SecretiveCLIInvocation: Sendable, Equatable {
             return .help
         case "create-secret":
             return .createSecret(try CreateSecret.parse(arguments: Array(filtered.dropFirst())))
+        case "install-agent":
+            return .installAgent
+        case "uninstall-agent":
+            return .uninstallAgent
+        case "agent-status":
+            return .agentStatus
+        case "socket-path":
+            return .socketPath
+        case "print-integration":
+            return .printIntegration(try PrintIntegration.parse(arguments: Array(filtered.dropFirst())))
         default:
             return .none
         }
@@ -25,11 +40,22 @@ public enum SecretiveCLIInvocation: Sendable, Equatable {
         """
         Usage:
           Secretive create-secret --name <name> [--protection-level <1|2|3>] [--key-type <\(CreateSecret.supportedKeyTypes.map(\.description).joined(separator: "|"))>] [--key-attribution <value>]
+          Secretive install-agent
+          Secretive uninstall-agent
+          Secretive agent-status
+          Secretive socket-path
+          Secretive print-integration --tool <\(PrintIntegration.Tool.allCases.map(\.rawValue).joined(separator: "|"))>
 
         Protection levels:
           1  require authentication
           2  notification
           3  current biometrics
+
+        Integration tools:
+          ssh   print ~/.ssh/config content using IdentityAgent
+          zsh   print ~/.zshrc content exporting SSH_AUTH_SOCK
+          bash  print ~/.bashrc content exporting SSH_AUTH_SOCK
+          fish  print ~/.config/fish/config.fish content exporting SSH_AUTH_SOCK
 
         Defaults:
           protection-level: 1
@@ -111,7 +137,7 @@ public enum SecretiveCLIInvocation: Sendable, Equatable {
             )
         }
 
-        private static func value(after option: String, arguments: [String], index: inout Int) throws -> String {
+        fileprivate static func value(after option: String, arguments: [String], index: inout Int) throws -> String {
             let valueIndex = index + 1
             guard arguments.indices.contains(valueIndex) else {
                 throw ParseError.missingValue(option)
@@ -156,10 +182,12 @@ public enum SecretiveCLIInvocation: Sendable, Equatable {
         case emptyValue(String)
         case invalidProtectionLevel(String)
         case invalidKeyType(String)
+        case invalidIntegrationTool(String)
         case unexpectedArgument(String)
 
         public var errorDescription: String? {
             let validKeyTypes = CreateSecret.supportedKeyTypes.map(\.description).joined(separator: ", ")
+            let validIntegrationTools = PrintIntegration.Tool.allCases.map(\.rawValue).joined(separator: ", ")
             switch self {
             case .helpRequested:
                 return SecretiveCLIInvocation.usage
@@ -173,9 +201,50 @@ public enum SecretiveCLIInvocation: Sendable, Equatable {
                 return "Invalid protection level '\(value)'. Valid values: 1, 2, 3."
             case let .invalidKeyType(value):
                 return "Invalid key type '\(value)'. Valid values: \(validKeyTypes)."
+            case let .invalidIntegrationTool(value):
+                return "Invalid integration tool '\(value)'. Valid values: \(validIntegrationTools)."
             case let .unexpectedArgument(argument):
                 return "Unexpected argument '\(argument)'."
             }
+        }
+    }
+
+    public struct PrintIntegration: Sendable, Equatable {
+        public let tool: Tool
+
+        static func parse(arguments: [String]) throws -> Self {
+            var tool: Tool?
+
+            var index = 0
+            while index < arguments.count {
+                let argument = arguments[index]
+                switch argument {
+                case "--help", "-h":
+                    throw ParseError.helpRequested
+                case "--tool":
+                    let rawValue = try CreateSecret.value(after: argument, arguments: arguments, index: &index)
+                    guard let parsedTool = Tool(rawValue: rawValue.lowercased()) else {
+                        throw ParseError.invalidIntegrationTool(rawValue)
+                    }
+                    tool = parsedTool
+                default:
+                    throw ParseError.unexpectedArgument(argument)
+                }
+                index += 1
+            }
+
+            guard let tool else {
+                throw ParseError.missingRequiredOption("--tool")
+            }
+
+            return Self(tool: tool)
+        }
+
+        public enum Tool: String, Sendable, Equatable, CaseIterable {
+            case ssh
+            case zsh
+            case bash
+            case fish
         }
     }
 }

--- a/Sources/Packages/Tests/SecretKitTests/SecretiveCLITests.swift
+++ b/Sources/Packages/Tests/SecretKitTests/SecretiveCLITests.swift
@@ -1,0 +1,96 @@
+import Testing
+@testable import SecretKit
+
+@Suite struct SecretiveCLITests {
+
+    @Test func parsesCreateSecretCommand() throws {
+        let invocation = try SecretiveCLIInvocation.parse(arguments: [
+            "create-secret",
+            "--name", "Fleet Deploy Key",
+            "--protection-level", "1",
+            "--key-type", "ecdsa-256",
+            "--key-attribution", "deploy@example.com",
+        ])
+
+        guard case let .createSecret(command) = invocation else {
+            Issue.record("Expected create-secret invocation")
+            return
+        }
+
+        #expect(command.name == "Fleet Deploy Key")
+        #expect(command.protectionLevel == .requireAuthentication)
+        #expect(command.attributes.authentication == .presenceRequired)
+        #expect(command.keyType == .ecdsa256)
+        #expect(command.keyAttribution == "deploy@example.com")
+    }
+
+    @Test func parsesNotificationProtectionLevel() throws {
+        let invocation = try SecretiveCLIInvocation.parse(arguments: [
+            "create-secret",
+            "--name", "Fleet Deploy Key",
+            "--protection-level", "2",
+            "--key-type", "mldsa-65",
+        ])
+
+        guard case let .createSecret(command) = invocation else {
+            Issue.record("Expected create-secret invocation")
+            return
+        }
+
+        #expect(command.protectionLevel == .notification)
+        #expect(command.attributes.authentication == .notRequired)
+        #expect(command.keyType == .mldsa65)
+        #expect(command.keyAttribution == nil)
+    }
+
+    @Test func usesDefaultsWhenOnlyNameIsProvided() throws {
+        let invocation = try SecretiveCLIInvocation.parse(arguments: [
+            "create-secret",
+            "--name", "Fleet Deploy Key",
+        ])
+
+        guard case let .createSecret(command) = invocation else {
+            Issue.record("Expected create-secret invocation")
+            return
+        }
+
+        #expect(command.protectionLevel == .requireAuthentication)
+        #expect(command.attributes.authentication == .presenceRequired)
+        #expect(command.keyType == .ecdsa256)
+        #expect(command.keyAttribution == nil)
+    }
+
+    @Test func supportsCurrentBiometricsAndCommonKeyTypeTypo() throws {
+        let invocation = try SecretiveCLIInvocation.parse(arguments: [
+            "create-secret",
+            "--name", "Fleet Deploy Key",
+            "--protection-level", "3",
+            "--key-type", "edcsa-256",
+        ])
+
+        guard case let .createSecret(command) = invocation else {
+            Issue.record("Expected create-secret invocation")
+            return
+        }
+
+        #expect(command.protectionLevel == .currentBiometrics)
+        #expect(command.attributes.authentication == .biometryCurrent)
+        #expect(command.keyType == .ecdsa256)
+    }
+
+    @Test func rejectsInvalidProtectionLevel() throws {
+        #expect(throws: SecretiveCLIInvocation.ParseError.invalidProtectionLevel("4")) {
+            try SecretiveCLIInvocation.parse(arguments: [
+                "create-secret",
+                "--name", "Fleet Deploy Key",
+                "--protection-level", "4",
+                "--key-type", "ecdsa-256",
+            ])
+        }
+    }
+
+    @Test func ignoresLaunchServicesProcessSerialNumber() throws {
+        let invocation = try SecretiveCLIInvocation.parse(arguments: ["-psn_0_12345"])
+        #expect(invocation == .none)
+    }
+}

--- a/Sources/Packages/Tests/SecretKitTests/SecretiveCLITests.swift
+++ b/Sources/Packages/Tests/SecretKitTests/SecretiveCLITests.swift
@@ -93,4 +93,34 @@ import Testing
         let invocation = try SecretiveCLIInvocation.parse(arguments: ["-psn_0_12345"])
         #expect(invocation == .none)
     }
+
+    @Test func parsesAgentCommands() throws {
+        #expect(try SecretiveCLIInvocation.parse(arguments: ["install-agent"]) == .installAgent)
+        #expect(try SecretiveCLIInvocation.parse(arguments: ["uninstall-agent"]) == .uninstallAgent)
+        #expect(try SecretiveCLIInvocation.parse(arguments: ["agent-status"]) == .agentStatus)
+        #expect(try SecretiveCLIInvocation.parse(arguments: ["socket-path"]) == .socketPath)
+    }
+
+    @Test func parsesPrintIntegrationCommand() throws {
+        let invocation = try SecretiveCLIInvocation.parse(arguments: [
+            "print-integration",
+            "--tool", "ssh",
+        ])
+
+        guard case let .printIntegration(command) = invocation else {
+            Issue.record("Expected print-integration invocation")
+            return
+        }
+
+        #expect(command.tool == .ssh)
+    }
+
+    @Test func rejectsInvalidIntegrationTool() throws {
+        #expect(throws: SecretiveCLIInvocation.ParseError.invalidIntegrationTool("powershell")) {
+            try SecretiveCLIInvocation.parse(arguments: [
+                "print-integration",
+                "--tool", "powershell",
+            ])
+        }
+    }
 }

--- a/Sources/Packages/Tests/SecretKitTests/SecretiveCLITests.swift
+++ b/Sources/Packages/Tests/SecretKitTests/SecretiveCLITests.swift
@@ -95,6 +95,7 @@ import Testing
     }
 
     @Test func parsesAgentCommands() throws {
+        #expect(try SecretiveCLIInvocation.parse(arguments: ["list-secrets"]) == .listSecrets)
         #expect(try SecretiveCLIInvocation.parse(arguments: ["install-agent"]) == .installAgent)
         #expect(try SecretiveCLIInvocation.parse(arguments: ["uninstall-agent"]) == .uninstallAgent)
         #expect(try SecretiveCLIInvocation.parse(arguments: ["agent-status"]) == .agentStatus)
@@ -120,6 +121,48 @@ import Testing
             try SecretiveCLIInvocation.parse(arguments: [
                 "print-integration",
                 "--tool", "powershell",
+            ])
+        }
+    }
+
+    @Test func parsesSecretSelectorCommands() throws {
+        let byID = try SecretiveCLIInvocation.parse(arguments: [
+            "public-key-path",
+            "--id", "1234",
+        ])
+        guard case let .publicKeyPath(selectorByID) = byID else {
+            Issue.record("Expected public-key-path invocation")
+            return
+        }
+        #expect(selectorByID.id == "1234")
+        #expect(selectorByID.name == nil)
+
+        let byName = try SecretiveCLIInvocation.parse(arguments: [
+            "export-public-key",
+            "--name", "Fleet Deploy Key",
+        ])
+        guard case let .exportPublicKey(selectorByName) = byName else {
+            Issue.record("Expected export-public-key invocation")
+            return
+        }
+        #expect(selectorByName.name == "Fleet Deploy Key")
+        #expect(selectorByName.id == nil)
+    }
+
+    @Test func rejectsMissingSecretSelector() throws {
+        #expect(throws: SecretiveCLIInvocation.ParseError.missingSecretSelector) {
+            try SecretiveCLIInvocation.parse(arguments: [
+                "public-key-path",
+            ])
+        }
+    }
+
+    @Test func rejectsConflictingSecretSelectors() throws {
+        #expect(throws: SecretiveCLIInvocation.ParseError.conflictingOptions("--id", "--name")) {
+            try SecretiveCLIInvocation.parse(arguments: [
+                "export-public-key",
+                "--name", "Fleet Deploy Key",
+                "--id", "1234",
             ])
         }
     }

--- a/Sources/Secretive/App.swift
+++ b/Sources/Secretive/App.swift
@@ -4,6 +4,7 @@ import SecretKit
 import SecureEnclaveSecretKit
 import SmartCardSecretKit
 import Brief
+import Common
 
 @main
 struct Secretive: App {
@@ -26,10 +27,15 @@ struct Secretive: App {
         case .help:
             Self.writeCLIOutput(SecretiveCLIInvocation.usage)
             exit(0)
-        case let .createSecret(command):
+        case .createSecret,
+                .installAgent,
+                .uninstallAgent,
+                .agentStatus,
+                .socketPath,
+                .printIntegration:
             NSApplication.shared.setActivationPolicy(.prohibited)
             Task { @MainActor in
-                let exitCode = await Self.runCLI(command: command)
+                let exitCode = await Self.runCLI(invocation: cliInvocation)
                 exit(Int32(exitCode))
             }
         }
@@ -71,7 +77,31 @@ struct Secretive: App {
 
 extension Secretive {
 
-    @MainActor static func runCLI(command: SecretiveCLIInvocation.CreateSecret) async -> Int {
+    @MainActor static func runCLI(invocation: SecretiveCLIInvocation) async -> Int {
+        switch invocation {
+        case let .createSecret(command):
+            return await runCreateSecretCLI(command: command)
+        case .installAgent:
+            return await runInstallAgentCLI()
+        case .uninstallAgent:
+            return await runUninstallAgentCLI()
+        case .agentStatus:
+            return runAgentStatusCLI()
+        case .socketPath:
+            writeCLIOutput(URL.socketPath)
+            return 0
+        case let .printIntegration(command):
+            writeCLIOutput(integrationInstructions(for: command.tool))
+            return 0
+        case .help:
+            writeCLIOutput(SecretiveCLIInvocation.usage)
+            return 0
+        case .none:
+            return 0
+        }
+    }
+
+    @MainActor private static func runCreateSecretCLI(command: SecretiveCLIInvocation.CreateSecret) async -> Int {
         let store = SecureEnclave.Store()
         guard store.isAvailable else {
             writeCLIError("Secure Enclave is not available on this Mac.")
@@ -97,9 +127,116 @@ extension Secretive {
             )
             return 0
         } catch {
-            writeCLIError(error.localizedDescription)
+            writeCLIError(describeCLIError(error))
             return 1
         }
+    }
+
+    @MainActor private static func runInstallAgentCLI() async -> Int {
+        let controller = AgentLaunchController()
+        do {
+            try await controller.install()
+            UserDefaults.standard.set(true, forKey: CLIConstants.setupCompleteKey)
+            UserDefaults.standard.set(false, forKey: CLIConstants.explicitlyDisabledKey)
+            controller.check()
+            writeCLIOutput(
+                """
+                installed: true
+                running: \(controller.running)
+                setup-complete: true
+                socket-path: \(URL.socketPath)
+                """
+            )
+            return controller.running ? 0 : 1
+        } catch {
+            writeCLIError(describeCLIError(error))
+            return 1
+        }
+    }
+
+    @MainActor private static func runUninstallAgentCLI() async -> Int {
+        let controller = AgentLaunchController()
+        do {
+            UserDefaults.standard.set(true, forKey: CLIConstants.explicitlyDisabledKey)
+            try await controller.uninstall()
+            controller.check()
+            writeCLIOutput(
+                """
+                installed: false
+                running: \(controller.running)
+                explicitly-disabled: true
+                """
+            )
+            return controller.running ? 1 : 0
+        } catch {
+            writeCLIError(describeCLIError(error))
+            return 1
+        }
+    }
+
+    @MainActor private static func runAgentStatusCLI() -> Int {
+        let controller = AgentLaunchController()
+        controller.check()
+
+        let setupComplete = UserDefaults.standard.bool(forKey: CLIConstants.setupCompleteKey)
+        let explicitlyDisabled = UserDefaults.standard.bool(forKey: CLIConstants.explicitlyDisabledKey)
+
+        var lines = [
+            "running: \(controller.running)",
+            "setup-complete: \(setupComplete)",
+            "explicitly-disabled: \(explicitlyDisabled)",
+            "socket-path: \(URL.socketPath)",
+        ]
+
+        if let process = controller.process, let bundleURL = process.bundleURL {
+            lines.append("agent-path: \(bundleURL.path())")
+            if let version = Bundle(url: bundleURL)?.infoDictionary?["CFBundleShortVersionString"] as? String {
+                lines.append("agent-version: \(version)")
+            }
+        }
+
+        writeCLIOutput(lines.joined(separator: "\n"))
+        return 0
+    }
+
+    private static func integrationInstructions(for tool: SecretiveCLIInvocation.PrintIntegration.Tool) -> String {
+        switch tool {
+        case .ssh:
+            """
+            # ~/.ssh/config
+            Host *
+            \tIdentityAgent \(URL.socketPath)
+            """
+        case .zsh:
+            """
+            # ~/.zshrc
+            export SSH_AUTH_SOCK=\(URL.socketPath)
+            """
+        case .bash:
+            """
+            # ~/.bashrc
+            export SSH_AUTH_SOCK=\(URL.socketPath)
+            """
+        case .fish:
+            """
+            # ~/.config/fish/config.fish
+            set -x SSH_AUTH_SOCK \(URL.socketPath)
+            """
+        }
+    }
+
+    private static func describeCLIError(_ error: Error) -> String {
+        if let keychainError = error as? KeychainError, let statusCode = keychainError.statusCode {
+            return "Keychain operation failed with status \(statusCode)."
+        }
+
+        let nsError = error as NSError
+        let localizedDescription = nsError.localizedDescription.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !localizedDescription.isEmpty {
+            return localizedDescription
+        }
+
+        return String(describing: error)
     }
 
     static func writeCLIOutput(_ text: String) {
@@ -109,6 +246,11 @@ extension Secretive {
     static func writeCLIError(_ text: String) {
         FileHandle.standardError.write(Data((text + "\n").utf8))
     }
+}
+
+private enum CLIConstants {
+    static let setupCompleteKey = "defaultsHasRunSetup"
+    static let explicitlyDisabledKey = "explicitlyDisabled"
 }
 
 extension Secretive {

--- a/Sources/Secretive/App.swift
+++ b/Sources/Secretive/App.swift
@@ -5,6 +5,7 @@ import SecureEnclaveSecretKit
 import SmartCardSecretKit
 import Brief
 import Common
+import SSHProtocolKit
 
 @main
 struct Secretive: App {
@@ -28,11 +29,14 @@ struct Secretive: App {
             Self.writeCLIOutput(SecretiveCLIInvocation.usage)
             exit(0)
         case .createSecret,
+                .listSecrets,
                 .installAgent,
                 .uninstallAgent,
                 .agentStatus,
                 .socketPath,
-                .printIntegration:
+                .printIntegration,
+                .publicKeyPath,
+                .exportPublicKey:
             NSApplication.shared.setActivationPolicy(.prohibited)
             Task { @MainActor in
                 let exitCode = await Self.runCLI(invocation: cliInvocation)
@@ -81,6 +85,8 @@ extension Secretive {
         switch invocation {
         case let .createSecret(command):
             return await runCreateSecretCLI(command: command)
+        case .listSecrets:
+            return await runListSecretsCLI()
         case .installAgent:
             return await runInstallAgentCLI()
         case .uninstallAgent:
@@ -93,6 +99,10 @@ extension Secretive {
         case let .printIntegration(command):
             writeCLIOutput(integrationInstructions(for: command.tool))
             return 0
+        case let .publicKeyPath(selector):
+            return await runPublicKeyPathCLI(selector: selector)
+        case let .exportPublicKey(selector):
+            return await runExportPublicKeyCLI(selector: selector)
         case .help:
             writeCLIOutput(SecretiveCLIInvocation.usage)
             return 0
@@ -199,6 +209,52 @@ extension Secretive {
         return 0
     }
 
+    @MainActor private static func runListSecretsCLI() async -> Int {
+        let storeList = await cliSecretStoreList()
+        let secrets = storeList.allSecrets
+
+        guard !secrets.isEmpty else {
+            return 0
+        }
+
+        let output = secrets.map { secret in
+            """
+            id: \(String(describing: secret.id))
+            name: \(secret.name)
+            key-type: \(secret.keyType)
+            key-attribution: \(secret.publicKeyAttribution ?? "")
+            public-key-path: \(publicKeyPath(for: secret))
+            certificate-path: \(certificatePath(for: secret))
+            """
+        }.joined(separator: "\n\n")
+
+        writeCLIOutput(output)
+        return 0
+    }
+
+    @MainActor private static func runPublicKeyPathCLI(selector: SecretiveCLIInvocation.SecretSelector) async -> Int {
+        do {
+            let secret = try await resolveSecret(for: selector)
+            writeCLIOutput(publicKeyPath(for: secret))
+            return 0
+        } catch {
+            writeCLIError(describeCLIError(error))
+            return 1
+        }
+    }
+
+    @MainActor private static func runExportPublicKeyCLI(selector: SecretiveCLIInvocation.SecretSelector) async -> Int {
+        do {
+            let secret = try await resolveSecret(for: selector)
+            let writer = OpenSSHPublicKeyWriter()
+            writeCLIOutput(writer.openSSHString(secret: secret))
+            return 0
+        } catch {
+            writeCLIError(describeCLIError(error))
+            return 1
+        }
+    }
+
     private static func integrationInstructions(for tool: SecretiveCLIInvocation.PrintIntegration.Tool) -> String {
         switch tool {
         case .ssh:
@@ -223,6 +279,45 @@ extension Secretive {
             set -x SSH_AUTH_SOCK \(URL.socketPath)
             """
         }
+    }
+
+    @MainActor private static func cliSecretStoreList() async -> SecretStoreList {
+        let storeList = EnvironmentValues._secretStoreList
+        for store in storeList.stores {
+            await store.reloadSecrets()
+        }
+        return storeList
+    }
+
+    @MainActor private static func resolveSecret(for selector: SecretiveCLIInvocation.SecretSelector) async throws -> AnySecret {
+        let storeList = await cliSecretStoreList()
+        let matches: [AnySecret]
+
+        if let id = selector.id {
+            matches = storeList.allSecrets.filter { String(describing: $0.id) == id }
+        } else if let name = selector.name {
+            matches = storeList.allSecrets.filter { $0.name == name }
+        } else {
+            throw CLIError.secretSelectorMissing
+        }
+
+        guard !matches.isEmpty else {
+            throw CLIError.secretNotFound(selector: selector)
+        }
+
+        guard matches.count == 1 else {
+            throw CLIError.secretSelectorAmbiguous(selector: selector, matches: matches.map { String(describing: $0.id) })
+        }
+
+        return matches[0]
+    }
+
+    private static func publicKeyPath<SecretType: Secret>(for secret: SecretType) -> String {
+        URL.publicKeyPath(for: secret, in: URL.publicKeyDirectory)
+    }
+
+    private static func certificatePath<SecretType: Secret>(for secret: SecretType) -> String {
+        publicKeyPath(for: secret).replacingOccurrences(of: ".pub", with: "-cert.pub")
     }
 
     private static func describeCLIError(_ error: Error) -> String {
@@ -251,6 +346,32 @@ extension Secretive {
 private enum CLIConstants {
     static let setupCompleteKey = "defaultsHasRunSetup"
     static let explicitlyDisabledKey = "explicitlyDisabled"
+}
+
+private enum CLIError: LocalizedError {
+    case secretSelectorMissing
+    case secretNotFound(selector: SecretiveCLIInvocation.SecretSelector)
+    case secretSelectorAmbiguous(selector: SecretiveCLIInvocation.SecretSelector, matches: [String])
+
+    var errorDescription: String? {
+        switch self {
+        case .secretSelectorMissing:
+            return "Specify exactly one of --id or --name."
+        case let .secretNotFound(selector):
+            if let id = selector.id {
+                return "No secret found with id '\(id)'."
+            }
+            if let name = selector.name {
+                return "No secret found with name '\(name)'."
+            }
+            return "No secret matched the provided selector."
+        case let .secretSelectorAmbiguous(selector, matches):
+            if let name = selector.name {
+                return "Multiple secrets matched name '\(name)'. Matching ids: \(matches.joined(separator: ", ")). Use --id instead."
+            }
+            return "Multiple secrets matched the provided selector. Matching ids: \(matches.joined(separator: ", "))."
+        }
+    }
 }
 
 extension Secretive {

--- a/Sources/Secretive/App.swift
+++ b/Sources/Secretive/App.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import AppKit
 import SecretKit
 import SecureEnclaveSecretKit
 import SmartCardSecretKit
@@ -9,6 +10,30 @@ struct Secretive: App {
     
     @Environment(\.agentLaunchController) var agentLaunchController
     @Environment(\.justUpdatedChecker) var justUpdatedChecker
+
+    init() {
+        let cliInvocation: SecretiveCLIInvocation
+        do {
+            cliInvocation = try SecretiveCLIInvocation.parse(arguments: Array(ProcessInfo.processInfo.arguments.dropFirst()))
+        } catch {
+            Self.writeCLIError(error.localizedDescription)
+            exit(1)
+        }
+
+        switch cliInvocation {
+        case .none:
+            break
+        case .help:
+            Self.writeCLIOutput(SecretiveCLIInvocation.usage)
+            exit(0)
+        case let .createSecret(command):
+            NSApplication.shared.setActivationPolicy(.prohibited)
+            Task { @MainActor in
+                let exitCode = await Self.runCLI(command: command)
+                exit(Int32(exitCode))
+            }
+        }
+    }
 
     @SceneBuilder var body: some Scene {
         WindowGroup {
@@ -42,6 +67,48 @@ struct Secretive: App {
         .windowResizability(.contentSize)
     }
 
+}
+
+extension Secretive {
+
+    @MainActor static func runCLI(command: SecretiveCLIInvocation.CreateSecret) async -> Int {
+        let store = SecureEnclave.Store()
+        guard store.isAvailable else {
+            writeCLIError("Secure Enclave is not available on this Mac.")
+            return 1
+        }
+
+        guard store.supportedKeyTypes.available.contains(command.keyType) else {
+            let available = store.supportedKeyTypes.available.map(\.description).joined(separator: ", ")
+            writeCLIError("Key type '\(command.keyType)' is not available on this macOS version. Available key types: \(available).")
+            return 1
+        }
+
+        do {
+            let secret = try await store.create(name: command.name, attributes: command.attributes)
+            writeCLIOutput(
+                """
+                id: \(secret.id)
+                name: \(secret.name)
+                protection-level: \(command.protectionLevel.rawValue)
+                key-type: \(secret.keyType)
+                key-attribution: \(secret.publicKeyAttribution ?? "")
+                """
+            )
+            return 0
+        } catch {
+            writeCLIError(error.localizedDescription)
+            return 1
+        }
+    }
+
+    static func writeCLIOutput(_ text: String) {
+        FileHandle.standardOutput.write(Data((text + "\n").utf8))
+    }
+
+    static func writeCLIError(_ text: String) {
+        FileHandle.standardError.write(Data((text + "\n").utf8))
+    }
 }
 
 extension Secretive {


### PR DESCRIPTION
## Why

Secretive currently assumes an interactive GUI setup flow. That works for individual users, but it breaks down for fleet deployment where a management tool like Kandji needs to provision Secretive ahead of time.

The goal of this PR is to make Secretive scriptable enough to support managed rollout of SSH signing keys, especially in environments using SSH certificates. With these commands, an automation can:

- install and verify the SecretAgent helper
- create a Secretive key with the required metadata
- discover the public key and its stand-in paths
- print the integration snippets needed to wire SSH or shell environments to Secretive

That makes it possible to automate the parts that currently require opening the app and clicking through setup, while keeping the existing GUI workflow intact.

## What Changed

This PR adds CLI support for:

- creating a secret with configurable name, protection level, key type, and attribution
- listing existing secrets
- installing, uninstalling, and inspecting SecretAgent state
- printing the SecretAgent socket path
- printing integration snippets for `ssh`, `zsh`, `bash`, and `fish`
- resolving a secret's public key path by `--id` or `--name`
- exporting a secret's public key by `--id` or `--name`

## Help Output

```text
Usage:
  Secretive create-secret --name <name> [--protection-level <1|2|3>] [--key-type <ecdsa-256|mldsa-65|mldsa-87>] [--key-attribution <value>]
  Secretive list-secrets
  Secretive install-agent
  Secretive uninstall-agent
  Secretive agent-status
  Secretive socket-path
  Secretive print-integration --tool <ssh|zsh|bash|fish>
  Secretive public-key-path (--id <id> | --name <name>)
  Secretive export-public-key (--id <id> | --name <name>)

Protection levels:
  1  require authentication
  2  notification
  3  current biometrics

Integration tools:
  ssh   print ~/.ssh/config content using IdentityAgent
  zsh   print ~/.zshrc content exporting SSH_AUTH_SOCK
  bash  print ~/.bashrc content exporting SSH_AUTH_SOCK
  fish  print ~/.config/fish/config.fish content exporting SSH_AUTH_SOCK

Defaults:
  protection-level: 1
  key-type: ecdsa-256
  key-attribution: omitted
```

## Testing

- `xcodebuild -project Sources/Secretive.xcodeproj -scheme Secretive -configuration Debug CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO build`
- `xcodebuild -project Sources/Secretive.xcodeproj -scheme PackageTests test CODE_SIGNING_ALLOWED=NO`
- manually exercised the signed Debug app CLI for:
  - `create-secret`
  - `list-secrets`
  - `public-key-path`
  - `export-public-key`
  - `install-agent`
  - `uninstall-agent`
  - `agent-status`
  - `socket-path`
  - `print-integration` variants

## Related Issues

- Related to #328 (`Command-line interface`)
- Related to #499 (`Make it possible to get a public key from the name chosen in Secretive via shell/CLI`)
- Adjacent context: #791 (`Support for 1-to-Many relationship between Key and Certificates`)
