### PR TITLE
Add configurable signing call limit for SecretAgent

### DIFF
--- a/Sources/Packages/Package.swift
+++ b/Sources/Packages/Package.swift
@@ -84,7 +84,7 @@ let package = Package(
         ),
         .testTarget(
             name: "SecretAgentKitTests",
-            dependencies: ["SecretAgentKit"],
+            dependencies: ["SecretAgentKit", "Common"],
         ),
         .target(
             name: "SSHProtocolKit",

--- a/Sources/Packages/Resources/Localizable.xcstrings
+++ b/Sources/Packages/Resources/Localizable.xcstrings
@@ -1660,6 +1660,23 @@
         }
       }
     },
+    "agent_details_disable_agent_failed_error" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Could not disable the agent. It may still be running."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法禁用 Agent，进程可能仍在运行。"
+          }
+        }
+      }
+    },
     "agent_details_restart_agent_button" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Sources/Packages/Resources/Localizable.xcstrings
+++ b/Sources/Packages/Resources/Localizable.xcstrings
@@ -2585,6 +2585,108 @@
         }
       }
     },
+    "agent_details_call_limit_label" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Call Limit"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "可调用次数"
+          }
+        }
+      }
+    },
+    "agent_details_call_limit_exhausted_notice" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The call limit was reached. Start the agent again to reset the counter."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "可调用次数已用尽。再次启动 Agent 将重置计数。"
+          }
+        }
+      }
+    },
+    "agent_details_call_limit_custom" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Custom"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自定义"
+          }
+        }
+      }
+    },
+    "agent_details_call_limit_custom_prompt" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "1-100"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1-100"
+          }
+        }
+      }
+    },
+    "agent_details_call_limit_remaining_title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Remaining Calls"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "剩余调用次数"
+          }
+        }
+      }
+    },
+    "agent_details_call_limit_unlimited" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No Limit"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不限制"
+          }
+        }
+      }
+    },
     "agent_details_version_title" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Sources/Packages/Sources/Common/AgentCallLimitSettings.swift
+++ b/Sources/Packages/Sources/Common/AgentCallLimitSettings.swift
@@ -1,0 +1,121 @@
+import Foundation
+
+/// Persists how many times SecretAgent may handle signing requests before stopping itself.
+public enum AgentCallLimitSettings {
+
+    public static let maxLimit = 100
+    public static let unlimited = 0
+
+    public struct State: Codable, Equatable, Sendable {
+        public var limit: Int
+        public var remaining: Int?
+
+        public init(limit: Int = 0, remaining: Int? = nil) {
+            self.limit = limit
+            self.remaining = remaining
+        }
+    }
+
+    private static let fileName = "agent-call-limit.json"
+    private static let lock = NSLock()
+
+    public static var fileURL: URL {
+        URL.agentHomeURL.appendingPathComponent(fileName)
+    }
+
+    public static func load() -> State {
+        lock.lock()
+        defer { lock.unlock() }
+        return loadUnlocked()
+    }
+
+    public static func setLimit(_ limit: Int) {
+        lock.lock()
+        defer { lock.unlock() }
+        var state = loadUnlocked()
+        state.limit = limit == unlimited ? unlimited : clamped(limit)
+        if state.limit == unlimited {
+            state.remaining = nil
+        }
+        saveUnlocked(state)
+    }
+
+    /// Resets the remaining count from the configured limit. Call immediately before launching SecretAgent.
+    public static func resetForLaunch() {
+        lock.lock()
+        defer { lock.unlock() }
+        var state = loadUnlocked()
+        if state.limit > unlimited {
+            state.remaining = state.limit
+        } else {
+            state.remaining = nil
+        }
+        saveUnlocked(state)
+    }
+
+    public static func clamped(_ value: Int) -> Int {
+        min(max(value, 1), maxLimit)
+    }
+
+    public static func isExhausted(_ state: State = load()) -> Bool {
+        state.limit > unlimited && state.remaining == 0
+    }
+
+    fileprivate static func persistRemaining(_ remaining: Int?, forLimit limit: Int) {
+        lock.lock()
+        defer { lock.unlock() }
+        var state = loadUnlocked()
+        state.limit = limit
+        state.remaining = remaining
+        saveUnlocked(state)
+    }
+
+    private static func loadUnlocked() -> State {
+        let url = fileURL
+        guard let data = try? Data(contentsOf: url),
+              let state = try? JSONDecoder().decode(State.self, from: data) else {
+            return State()
+        }
+        return state
+    }
+
+    private static func saveUnlocked(_ state: State) {
+        let url = fileURL
+        let directory = url.deletingLastPathComponent()
+        try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        guard let data = try? JSONEncoder().encode(state) else { return }
+        try? data.write(to: url, options: .atomic)
+    }
+
+}
+
+/// In-process signing counter. Loaded once when SecretAgent starts; no per-request disk reads.
+public final class AgentCallLimitTracker: @unchecked Sendable {
+
+    private let lock = NSLock()
+    private let limit: Int
+    private var remaining: Int?
+
+    public init(state: AgentCallLimitSettings.State = AgentCallLimitSettings.load()) {
+        limit = state.limit
+        if state.limit > AgentCallLimitSettings.unlimited {
+            remaining = state.remaining ?? state.limit
+        } else {
+            remaining = nil
+        }
+    }
+
+    /// Records one signing request. Returns `true` when the agent should stop.
+    public func recordSignRequest() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        guard limit > AgentCallLimitSettings.unlimited, var count = remaining else {
+            return false
+        }
+        count -= 1
+        remaining = count
+        AgentCallLimitSettings.persistRemaining(count, forLimit: limit)
+        return count <= 0
+    }
+
+}

--- a/Sources/Packages/Tests/SecretAgentKitTests/AgentCallLimitSettingsTests.swift
+++ b/Sources/Packages/Tests/SecretAgentKitTests/AgentCallLimitSettingsTests.swift
@@ -1,0 +1,40 @@
+import Foundation
+import Testing
+import Common
+
+@Suite struct AgentCallLimitSettingsTests {
+
+    @Test func trackerStopsAfterConfiguredSignRequests() throws {
+        let url = AgentCallLimitSettings.fileURL
+        let backup = try? Data(contentsOf: url)
+        defer {
+            if let backup {
+                try? backup.write(to: url)
+            } else {
+                try? FileManager.default.removeItem(at: url)
+            }
+        }
+
+        let state = AgentCallLimitSettings.State(limit: 2, remaining: 2)
+        let data = try JSONEncoder().encode(state)
+        try data.write(to: url)
+
+        let tracker = AgentCallLimitTracker(state: state)
+        #expect(tracker.recordSignRequest() == false)
+        #expect(tracker.recordSignRequest() == true)
+        #expect(AgentCallLimitSettings.load().remaining == 0)
+    }
+
+    @Test func unlimitedTrackerNeverStops() {
+        let tracker = AgentCallLimitTracker(state: .init(limit: 0, remaining: nil))
+        #expect(tracker.recordSignRequest() == false)
+        #expect(tracker.recordSignRequest() == false)
+    }
+
+    @Test func exhaustedWhenRemainingIsZero() {
+        #expect(AgentCallLimitSettings.isExhausted(.init(limit: 3, remaining: 0)))
+        #expect(!AgentCallLimitSettings.isExhausted(.init(limit: 3, remaining: 1)))
+        #expect(!AgentCallLimitSettings.isExhausted(.init(limit: 0, remaining: nil)))
+    }
+
+}

--- a/Sources/SecretAgent/AppDelegate.swift
+++ b/Sources/SecretAgent/AppDelegate.swift
@@ -46,6 +46,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         return SocketController(path: path)
     }()
     private let logger = Logger(subsystem: "com.maxgoedjen.secretive.secretagent", category: "AppDelegate")
+    private let callLimitTracker = AgentCallLimitTracker()
 
     func applicationDidFinishLaunching(_ aNotification: Notification) {
         logger.debug("SecretAgent finished launching")
@@ -58,6 +59,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                             let request = try await inputParser.parse(data: message)
                             let agentResponse = await agent.handle(request: request, provenance: session.provenance)
                             try session.write(agentResponse)
+                            if case .signRequest = request, callLimitTracker.recordSignRequest() {
+                                logger.debug("Agent call limit reached, stopping")
+                                await MainActor.run {
+                                    NSApplication.shared.terminate(nil)
+                                }
+                            }
                         }
                     } catch {
                         try session.close()

--- a/Sources/Secretive.xcodeproj/project.pbxproj
+++ b/Sources/Secretive.xcodeproj/project.pbxproj
@@ -66,6 +66,7 @@
 		50B8550D24138C4F009958AC /* DeleteSecretView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50B8550C24138C4F009958AC /* DeleteSecretView.swift */; };
 		50BB046B2418AAAE00D6E079 /* EmptyStoreView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50BB046A2418AAAE00D6E079 /* EmptyStoreView.swift */; };
 		50BDCB722E63BAF20072D2E7 /* AgentStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50BDCB712E63BAF20072D2E7 /* AgentStatusView.swift */; };
+		50F1A0012F8A100100A1B2C3 /* AgentCallLimitPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F1A0002F8A100100A1B2C3 /* AgentCallLimitPicker.swift */; };
 		50BDCB742E6436CA0072D2E7 /* ErrorStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50BDCB732E6436C60072D2E7 /* ErrorStyle.swift */; };
 		50BDCB762E6450950072D2E7 /* ConfigurationItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50BDCB752E6450950072D2E7 /* ConfigurationItemView.swift */; };
 		50C385A52407A76D00AF2719 /* SecretDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50C385A42407A76D00AF2719 /* SecretDetailView.swift */; };
@@ -268,6 +269,7 @@
 		50B8550C24138C4F009958AC /* DeleteSecretView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeleteSecretView.swift; sourceTree = "<group>"; };
 		50BB046A2418AAAE00D6E079 /* EmptyStoreView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyStoreView.swift; sourceTree = "<group>"; };
 		50BDCB712E63BAF20072D2E7 /* AgentStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentStatusView.swift; sourceTree = "<group>"; };
+		50F1A0002F8A100100A1B2C3 /* AgentCallLimitPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentCallLimitPicker.swift; sourceTree = "<group>"; };
 		50BDCB732E6436C60072D2E7 /* ErrorStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorStyle.swift; sourceTree = "<group>"; };
 		50BDCB752E6450950072D2E7 /* ConfigurationItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationItemView.swift; sourceTree = "<group>"; };
 		50C385A42407A76D00AF2719 /* SecretDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecretDetailView.swift; sourceTree = "<group>"; };
@@ -400,6 +402,7 @@
 			children = (
 				50E4C4C22E7765DF00C73783 /* AboutView.swift */,
 				50BDCB712E63BAF20072D2E7 /* AgentStatusView.swift */,
+				50F1A0002F8A100100A1B2C3 /* AgentCallLimitPicker.swift */,
 				50617D8423FCE48E0099B055 /* ContentView.swift */,
 				5066A6C72516FE6E004B5A36 /* CopyableView.swift */,
 				50E204EE2FAA9C1400402380 /* MultilineInfoView.swift */,
@@ -822,6 +825,7 @@
 				5079BA0F250F29BF00EA86F4 /* StoreListView.swift in Sources */,
 				50617DD223FCEFA90099B055 /* PreviewStore.swift in Sources */,
 				50BDCB722E63BAF20072D2E7 /* AgentStatusView.swift in Sources */,
+				50F1A0012F8A100100A1B2C3 /* AgentCallLimitPicker.swift in Sources */,
 				508A58B3241ED2180069DC07 /* AgentStatusChecker.swift in Sources */,
 				50C385A52407A76D00AF2719 /* SecretDetailView.swift in Sources */,
 				5099A02423FD2AAA0062B6F2 /* CreateSecretView.swift in Sources */,

--- a/Sources/Secretive/App.swift
+++ b/Sources/Secretive/App.swift
@@ -4,7 +4,6 @@ import SecureEnclaveSecretKit
 import SmartCardSecretKit
 import Brief
 import CertificateKit
-import Common
 
 @main
 struct Secretive: App {
@@ -25,7 +24,7 @@ struct Secretive: App {
                         agentLaunchController.check()
                         guard !agentLaunchController.developmentBuild else { return }
                         if justUpdatedChecker.justUpdatedBuild || !agentLaunchController.running {
-                            guard !AgentCallLimitSettings.isExhausted() else { return }
+                            guard !agentLaunchController.isCallLimitExhausted else { return }
                             // Relaunch the agent, since it'll be running from earlier update still
                             try await agentLaunchController.forceLaunch()
                         }

--- a/Sources/Secretive/App.swift
+++ b/Sources/Secretive/App.swift
@@ -4,6 +4,7 @@ import SecureEnclaveSecretKit
 import SmartCardSecretKit
 import Brief
 import CertificateKit
+import Common
 
 @main
 struct Secretive: App {
@@ -24,6 +25,7 @@ struct Secretive: App {
                         agentLaunchController.check()
                         guard !agentLaunchController.developmentBuild else { return }
                         if justUpdatedChecker.justUpdatedBuild || !agentLaunchController.running {
+                            guard !AgentCallLimitSettings.isExhausted() else { return }
                             // Relaunch the agent, since it'll be running from earlier update still
                             try await agentLaunchController.forceLaunch()
                         }

--- a/Sources/Secretive/Controllers/AgentStatusChecker.swift
+++ b/Sources/Secretive/Controllers/AgentStatusChecker.swift
@@ -71,9 +71,28 @@ import Common
 
     func uninstall() async throws {
         logger.debug("Uninstalling agent")
+        await terminateInstanceAgentIfNeeded()
         try await Task.sleep(for: .seconds(1))
         try await service.unregister()
         try await Task.sleep(for: .seconds(1))
+        check()
+    }
+
+    private func terminateInstanceAgentIfNeeded() async {
+        guard let agent = instanceSecretAgentProcess else { return }
+        logger.debug("Terminating running agent before uninstall")
+        agent.terminate()
+        for _ in 0..<15 {
+            try? await Task.sleep(for: .milliseconds(200))
+            check()
+            if !running {
+                logger.debug("Agent terminated")
+                return
+            }
+        }
+        logger.warning("Agent did not exit after terminate, forcing")
+        instanceSecretAgentProcess?.forceTerminate()
+        try? await Task.sleep(for: .milliseconds(500))
         check()
     }
 

--- a/Sources/Secretive/Controllers/AgentStatusChecker.swift
+++ b/Sources/Secretive/Controllers/AgentStatusChecker.swift
@@ -10,10 +10,21 @@ import Common
     var running: Bool { get }
     var developmentBuild: Bool { get }
     var process: NSRunningApplication? { get }
+    var isCallLimitExhausted: Bool { get }
+    var callLimitRemaining: Int? { get }
     func check()
     func install() async throws
     func uninstall() async throws
+    func disable() async throws
     func forceLaunch() async throws
+}
+
+extension AgentLaunchControllerProtocol {
+
+    func disable() async throws {
+        try await uninstall()
+    }
+
 }
 
 @Observable @MainActor final class AgentLaunchController: AgentLaunchControllerProtocol {
@@ -27,6 +38,16 @@ import Common
         Task { @MainActor in
             check()
         }
+    }
+
+    var isCallLimitExhausted: Bool {
+        AgentCallLimitSettings.isExhausted()
+    }
+
+    var callLimitRemaining: Int? {
+        let state = AgentCallLimitSettings.load()
+        guard state.limit > AgentCallLimitSettings.unlimited else { return nil }
+        return state.remaining
     }
 
     func check() {
@@ -76,6 +97,10 @@ import Common
         try await service.unregister()
         try await Task.sleep(for: .seconds(1))
         check()
+        if running {
+            logger.error("Agent is still running after uninstall")
+            throw AgentLaunchError.agentStillRunning
+        }
     }
 
     private func terminateInstanceAgentIfNeeded() async {
@@ -98,6 +123,9 @@ import Common
 
     func forceLaunch() async throws {
         logger.debug("Agent is not running, attempting to force launch by reinstalling")
+        if running {
+            await terminateInstanceAgentIfNeeded()
+        }
         AgentCallLimitSettings.resetForLaunch()
         try await install()
         if running {
@@ -118,6 +146,17 @@ import Common
         check()
     }
 
+}
+
+enum AgentLaunchError: LocalizedError {
+    case agentStillRunning
+
+    var errorDescription: String? {
+        switch self {
+        case .agentStillRunning:
+            return String(localized: .agentDetailsDisableAgentFailedError)
+        }
+    }
 }
 
 extension URL {

--- a/Sources/Secretive/Controllers/AgentStatusChecker.swift
+++ b/Sources/Secretive/Controllers/AgentStatusChecker.swift
@@ -79,6 +79,7 @@ import Common
 
     func forceLaunch() async throws {
         logger.debug("Agent is not running, attempting to force launch by reinstalling")
+        AgentCallLimitSettings.resetForLaunch()
         try await install()
         if running {
             logger.debug("Agent successfully force launched by reinstalling")

--- a/Sources/Secretive/Preview Content/PreviewAgentStatusChecker.swift
+++ b/Sources/Secretive/Preview Content/PreviewAgentStatusChecker.swift
@@ -6,6 +6,8 @@ class PreviewAgentLaunchController: AgentLaunchControllerProtocol {
     let running: Bool
     let process: NSRunningApplication?
     let developmentBuild = false
+    let isCallLimitExhausted = false
+    let callLimitRemaining: Int? = nil
 
     init(running: Bool = true, process: NSRunningApplication? = nil) {
         self.running = running

--- a/Sources/Secretive/Views/Views/AgentCallLimitPicker.swift
+++ b/Sources/Secretive/Views/Views/AgentCallLimitPicker.swift
@@ -31,6 +31,7 @@ struct AgentCallLimitPicker: View {
             Text(.agentDetailsCallLimitLabel)
                 .font(.body)
                 .foregroundStyle(.primary)
+                .fixedSize(horizontal: true, vertical: false)
             Picker("", selection: $selection) {
                 Text(.agentDetailsCallLimitUnlimited)
                     .tag(AgentCallLimitSelection.unlimited)

--- a/Sources/Secretive/Views/Views/AgentCallLimitPicker.swift
+++ b/Sources/Secretive/Views/Views/AgentCallLimitPicker.swift
@@ -1,0 +1,100 @@
+import SwiftUI
+import Common
+
+private enum AgentCallLimitSelection: Hashable {
+    case unlimited
+    case preset(Int)
+    case custom
+}
+
+struct AgentCallLimitPicker: View {
+
+    @State private var selection: AgentCallLimitSelection
+    @State private var customValue = ""
+    @FocusState private var customFieldFocused: Bool
+
+    init() {
+        let state = AgentCallLimitSettings.load()
+        if state.limit == AgentCallLimitSettings.unlimited {
+            _selection = State(initialValue: .unlimited)
+        } else if (1...5).contains(state.limit) {
+            _selection = State(initialValue: .preset(state.limit))
+            _customValue = State(initialValue: "")
+        } else {
+            _selection = State(initialValue: .custom)
+            _customValue = State(initialValue: String(state.limit))
+        }
+    }
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Text(.agentDetailsCallLimitLabel)
+                .font(.body)
+                .foregroundStyle(.primary)
+            Picker("", selection: $selection) {
+                Text(.agentDetailsCallLimitUnlimited)
+                    .tag(AgentCallLimitSelection.unlimited)
+                ForEach(1...5, id: \.self) { count in
+                    Text(verbatim: String(count))
+                        .tag(AgentCallLimitSelection.preset(count))
+                }
+                Text(.agentDetailsCallLimitCustom)
+                    .tag(AgentCallLimitSelection.custom)
+            }
+            .labelsHidden()
+            .font(.body)
+            .foregroundStyle(.primary)
+            .fixedSize()
+            .onChange(of: selection) { _, newSelection in
+                if newSelection == .custom {
+                    customFieldFocused = true
+                }
+                commitCurrentSelection()
+            }
+
+            if selection == .custom {
+                TextField("", text: $customValue, prompt: Text(.agentDetailsCallLimitCustomPrompt))
+                    .font(.body)
+                    .frame(width: 44)
+                    .multilineTextAlignment(.trailing)
+                    .focused($customFieldFocused)
+                    .onSubmit(commitCustomValue)
+                    .onChange(of: customValue) { _, newValue in
+                        let filtered = newValue.filter(\.isNumber)
+                        if filtered != newValue {
+                            customValue = filtered
+                        }
+                        commitCustomValue()
+                    }
+            }
+        }
+    }
+
+    private func persistLimit(_ limit: Int) {
+        AgentCallLimitSettings.setLimit(limit)
+    }
+
+    private var resolvedCustomCount: Int? {
+        guard let value = Int(customValue), (1...AgentCallLimitSettings.maxLimit).contains(value) else {
+            return nil
+        }
+        return value
+    }
+
+    private func commitCustomValue() {
+        guard selection == .custom, let count = resolvedCustomCount else { return }
+        persistLimit(count)
+    }
+
+    private func commitCurrentSelection() {
+        switch selection {
+        case .unlimited:
+            persistLimit(AgentCallLimitSettings.unlimited)
+        case .preset(let count):
+            persistLimit(count)
+        case .custom:
+            commitCustomValue()
+        }
+    }
+
+}

--- a/Sources/Secretive/Views/Views/AgentStatusView.swift
+++ b/Sources/Secretive/Views/Views/AgentStatusView.swift
@@ -6,11 +6,15 @@ struct AgentStatusView: View {
     @Environment(\.agentLaunchController) private var agentLaunchController: any AgentLaunchControllerProtocol
 
     var body: some View {
-        if agentLaunchController.running {
-            AgentRunningView()
-        } else {
-            AgentNotRunningView()
+        Group {
+            if agentLaunchController.running {
+                AgentRunningView()
+            } else {
+                AgentNotRunningView()
+            }
         }
+        .frame(width: 440)
+        .fixedSize(horizontal: false, vertical: true)
     }
 }
 struct AgentRunningView: View {
@@ -75,7 +79,7 @@ struct AgentRunningView: View {
 
         }
         .formStyle(.grouped)
-        .frame(width: 440)
+        .scrollDisabled(true)
     }
 
 }
@@ -153,7 +157,7 @@ struct AgentNotRunningView: View {
             }
         }
         .formStyle(.grouped)
-        .frame(width: 440)
+        .scrollDisabled(true)
     }
 
 }

--- a/Sources/Secretive/Views/Views/AgentStatusView.swift
+++ b/Sources/Secretive/Views/Views/AgentStatusView.swift
@@ -56,22 +56,23 @@ struct AgentRunningView: View {
                 VStack(alignment: .leading, spacing: 10) {
                     Text(.agentRunningNoticeDetailDescription)
                     HStack {
-                        Spacer()
-                        Menu(.agentDetailsRestartAgentButton) {
-                            Button(.agentDetailsDisableAgentButton) {
-                                Task {
-                                    await disableAgent(
-                                        explicitlyDisabled: $explicitlyDisabled,
-                                        agentLaunchController: agentLaunchController
-                                    )
-                                }
-                            }
-                        } primaryAction: {
+                        Button(.agentDetailsRestartAgentButton) {
                             Task {
                                 explicitlyDisabled = false
                                 try? await agentLaunchController.forceLaunch()
                             }
                         }
+                        .primaryButton()
+                        Spacer()
+                        Button(.agentDetailsDisableAgentButton) {
+                            Task {
+                                await disableAgent(
+                                    explicitlyDisabled: $explicitlyDisabled,
+                                    agentLaunchController: agentLaunchController
+                                )
+                            }
+                        }
+                        .danger()
                     }
                 }
                 .padding(.vertical)
@@ -145,6 +146,7 @@ struct AgentNotRunningView: View {
                                         )
                                     }
                                 }
+                                .danger()
                             }
                         }
                     } else {

--- a/Sources/Secretive/Views/Views/AgentStatusView.swift
+++ b/Sources/Secretive/Views/Views/AgentStatusView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import Common
 
 struct AgentStatusView: View {
 
@@ -41,6 +42,7 @@ struct AgentRunningView: View {
                             value: launchDate.formatted()
                         )
                     }
+                    AgentCallLimitRemainingView()
                 }
             } header: {
                 Text(.agentRunningNoticeDetailTitle)
@@ -71,7 +73,7 @@ struct AgentRunningView: View {
 
         }
         .formStyle(.grouped)
-        .frame(width: 400)
+        .frame(width: 440)
     }
 
 }
@@ -93,8 +95,13 @@ struct AgentNotRunningView: View {
             } footer: {
                 VStack(alignment: .leading, spacing: 10) {
                     Text(.agentNotRunningNoticeDetailDescription)
-                    HStack {
+                    if AgentCallLimitSettings.isExhausted() {
+                        Text(.agentDetailsCallLimitExhaustedNotice)
+                            .foregroundStyle(.secondary)
+                    }
+                    HStack(spacing: 8) {
                         if !triedRestart {
+                            AgentCallLimitPicker()
                             Spacer()
                             Button {
                                 explicitlyDisabled = false
@@ -131,7 +138,32 @@ struct AgentNotRunningView: View {
             }
         }
         .formStyle(.grouped)
-        .frame(width: 400)
+        .frame(width: 440)
+    }
+
+}
+
+private struct AgentCallLimitRemainingView: View {
+
+    @State private var remaining: Int?
+    @State private var limit: Int = AgentCallLimitSettings.unlimited
+
+    var body: some View {
+        Group {
+            if limit > AgentCallLimitSettings.unlimited, let remaining {
+                ConfigurationItemView(
+                    title: .agentDetailsCallLimitRemainingTitle,
+                    value: String(remaining)
+                )
+            }
+        }
+        .onAppear(perform: refresh)
+    }
+
+    private func refresh() {
+        let state = AgentCallLimitSettings.load()
+        limit = state.limit
+        remaining = state.remaining
     }
 
 }

--- a/Sources/Secretive/Views/Views/AgentStatusView.swift
+++ b/Sources/Secretive/Views/Views/AgentStatusView.swift
@@ -56,13 +56,15 @@ struct AgentRunningView: View {
                         Menu(.agentDetailsRestartAgentButton) {
                             Button(.agentDetailsDisableAgentButton) {
                                 Task {
-                                    explicitlyDisabled = true
-                                    try? await agentLaunchController
-                                        .uninstall()
+                                    await disableAgent(
+                                        explicitlyDisabled: $explicitlyDisabled,
+                                        agentLaunchController: agentLaunchController
+                                    )
                                 }
                             }
                         } primaryAction: {
                             Task {
+                                explicitlyDisabled = false
                                 try? await agentLaunchController.forceLaunch()
                             }
                         }
@@ -99,8 +101,8 @@ struct AgentNotRunningView: View {
                         Text(.agentDetailsCallLimitExhaustedNotice)
                             .foregroundStyle(.secondary)
                     }
-                    HStack(spacing: 8) {
-                        if !triedRestart {
+                    if !triedRestart {
+                        HStack(spacing: 8) {
                             AgentCallLimitPicker()
                             Spacer()
                             Button {
@@ -127,11 +129,24 @@ struct AgentNotRunningView: View {
                                 }
                             }
                             .primaryButton()
-                        } else {
-                            Text(.agentDetailsCouldNotStartError)
-                                .bold()
-                                .foregroundStyle(.red)
                         }
+                        if !explicitlyDisabled && !loading {
+                            HStack {
+                                Spacer()
+                                Button(.agentDetailsDisableAgentButton) {
+                                    Task {
+                                        await disableAgent(
+                                            explicitlyDisabled: $explicitlyDisabled,
+                                            agentLaunchController: agentLaunchController
+                                        )
+                                    }
+                                }
+                            }
+                        }
+                    } else {
+                        Text(.agentDetailsCouldNotStartError)
+                            .bold()
+                            .foregroundStyle(.red)
                     }
                 }
                 .padding(.bottom)
@@ -141,6 +156,16 @@ struct AgentNotRunningView: View {
         .frame(width: 440)
     }
 
+}
+
+@MainActor
+private func disableAgent(
+    explicitlyDisabled: Binding<Bool>,
+    agentLaunchController: any AgentLaunchControllerProtocol
+) async {
+    explicitlyDisabled.wrappedValue = true
+    try? await agentLaunchController.uninstall()
+    agentLaunchController.check()
 }
 
 private struct AgentCallLimitRemainingView: View {

--- a/Sources/Secretive/Views/Views/AgentStatusView.swift
+++ b/Sources/Secretive/Views/Views/AgentStatusView.swift
@@ -21,6 +21,7 @@ struct AgentRunningView: View {
 
     @Environment(\.agentLaunchController) private var agentLaunchController: any AgentLaunchControllerProtocol
     @AppStorage("explicitlyDisabled") var explicitlyDisabled = false
+    @State private var disableErrorText: String?
 
     var body: some View {
         Form {
@@ -55,9 +56,14 @@ struct AgentRunningView: View {
             } footer: {
                 VStack(alignment: .leading, spacing: 10) {
                     Text(.agentRunningNoticeDetailDescription)
+                    if let disableErrorText {
+                        Text(verbatim: disableErrorText)
+                            .errorStyle()
+                    }
                     HStack {
                         Button(.agentDetailsRestartAgentButton) {
                             Task {
+                                disableErrorText = nil
                                 explicitlyDisabled = false
                                 try? await agentLaunchController.forceLaunch()
                             }
@@ -66,7 +72,7 @@ struct AgentRunningView: View {
                         Spacer()
                         Button(.agentDetailsDisableAgentButton) {
                             Task {
-                                await disableAgent(
+                                disableErrorText = await disableAgent(
                                     explicitlyDisabled: $explicitlyDisabled,
                                     agentLaunchController: agentLaunchController
                                 )
@@ -90,6 +96,7 @@ struct AgentNotRunningView: View {
     @Environment(\.agentLaunchController) private var agentLaunchController
     @State var triedRestart = false
     @State var loading = false
+    @State private var disableErrorText: String?
     @AppStorage("explicitlyDisabled") var explicitlyDisabled = false
 
     var body: some View {
@@ -102,15 +109,20 @@ struct AgentNotRunningView: View {
             } footer: {
                 VStack(alignment: .leading, spacing: 10) {
                     Text(.agentNotRunningNoticeDetailDescription)
-                    if AgentCallLimitSettings.isExhausted() {
+                    if !explicitlyDisabled && agentLaunchController.isCallLimitExhausted {
                         Text(.agentDetailsCallLimitExhaustedNotice)
                             .foregroundStyle(.secondary)
+                    }
+                    if let disableErrorText {
+                        Text(verbatim: disableErrorText)
+                            .errorStyle()
                     }
                     if !triedRestart {
                         HStack(spacing: 8) {
                             AgentCallLimitPicker()
                             Spacer()
                             Button {
+                                disableErrorText = nil
                                 explicitlyDisabled = false
                                 guard !loading else { return }
                                 loading = true
@@ -140,7 +152,7 @@ struct AgentNotRunningView: View {
                                 Spacer()
                                 Button(.agentDetailsDisableAgentButton) {
                                     Task {
-                                        await disableAgent(
+                                        disableErrorText = await disableAgent(
                                             explicitlyDisabled: $explicitlyDisabled,
                                             agentLaunchController: agentLaunchController
                                         )
@@ -168,20 +180,27 @@ struct AgentNotRunningView: View {
 private func disableAgent(
     explicitlyDisabled: Binding<Bool>,
     agentLaunchController: any AgentLaunchControllerProtocol
-) async {
+) async -> String? {
     explicitlyDisabled.wrappedValue = true
-    try? await agentLaunchController.uninstall()
-    agentLaunchController.check()
+    do {
+        try await agentLaunchController.disable()
+        agentLaunchController.check()
+        return nil
+    } catch {
+        explicitlyDisabled.wrappedValue = false
+        agentLaunchController.check()
+        return error.localizedDescription
+    }
 }
 
 private struct AgentCallLimitRemainingView: View {
 
+    @Environment(\.agentLaunchController) private var agentLaunchController
     @State private var remaining: Int?
-    @State private var limit: Int = AgentCallLimitSettings.unlimited
 
     var body: some View {
         Group {
-            if limit > AgentCallLimitSettings.unlimited, let remaining {
+            if let remaining {
                 ConfigurationItemView(
                     title: .agentDetailsCallLimitRemainingTitle,
                     value: String(remaining)
@@ -189,12 +208,13 @@ private struct AgentCallLimitRemainingView: View {
             }
         }
         .onAppear(perform: refresh)
+        .onReceive(Timer.publish(every: 2, on: .main, in: .common).autoconnect()) { _ in
+            refresh()
+        }
     }
 
     private func refresh() {
-        let state = AgentCallLimitSettings.load()
-        limit = state.limit
-        remaining = state.remaining
+        remaining = agentLaunchController.callLimitRemaining
     }
 
 }

--- a/Sources/Secretive/Views/Views/ContentView.swift
+++ b/Sources/Secretive/Views/Views/ContentView.swift
@@ -171,6 +171,7 @@ extension ContentView {
         )
         .popover(isPresented: $showingAgentInfo, attachmentAnchor: attachmentAnchor, arrowEdge: .bottom) {
             AgentStatusView()
+                .id(agentLaunchController.running)
         }
     }
 


### PR DESCRIPTION
## Summary

- Add a configurable **signing call limit** for SecretAgent: users can choose unlimited (default), presets 1–5, or a custom value up to 100 from the agent status popover.
- Count only `signRequest` operations; when the limit is reached, SecretAgent terminates itself and Secretive avoids auto-relaunching until the user starts the agent again.
- Improve agent lifecycle controls: more reliable disable (terminate running agent + unregister login item), split restart/disable actions when running, and fix popover layout when launch state changes.

## Test plan

- [ ] Launch Secretive, open agent status popover, verify call-limit picker appears next to Launch with unlimited default
- [ ] Set limit to 1, launch agent, trigger one SSH signing request — agent should stop and not auto-relaunch on app focus
- [ ] Set limit to 3, launch agent, verify counter decrements only on signing requests (not other XPC calls)
- [ ] While agent is running, use Restart and Disable buttons; confirm Disable kills the process and removes login item
- [ ] Run `swift test` in `Sources/Packages` — `AgentCallLimitSettingsTests` should pass


Made with [Cursor](https://cursor.com)