### PR TITLE
chore: Enable dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "swift"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
This configuration enables automatic dependabot updates (e.g. to not update [GitHub Actions Hashes](https://github.com/maxgoedjen/secretive/pull/809) manually 🙂).