### PR TITLE
Fix keyType constants being Data instead of String, specify in update calls

### DIFF
--- a/Sources/Packages/Sources/CertificateKit/CertificateStore.swift
+++ b/Sources/Packages/Sources/CertificateKit/CertificateStore.swift
@@ -67,6 +67,7 @@ import SecretKit
     public func update(certificate: Certificate) throws {
         let updateQuery = KeychainDictionary([
             kSecClass: Constants.keyClass,
+            kSecAttrService: Constants.keyTag,
             kSecAttrAccount: certificate.id,
         ])
 
@@ -134,7 +135,7 @@ extension CertificateStore {
 
     enum Constants {
         static let keyClass = kSecClassGenericPassword as String
-        static let keyTag = Data("com.maxgoedjen.certificatestore.opensshcertificate".utf8)
+        static let keyTag = "com.maxgoedjen.certificatestore.opensshcertificate"
         static let notificationToken = UUID().uuidString
     }
     

--- a/Sources/Packages/Sources/SecureEnclaveSecretKit/SecureEnclaveStore.swift
+++ b/Sources/Packages/Sources/SecureEnclaveSecretKit/SecureEnclaveStore.swift
@@ -183,6 +183,7 @@ extension SecureEnclave {
             let attributes = try JSONEncoder().encode(attributes)
             let updatedAttributes = KeychainDictionary([
                 kSecAttrLabel: name,
+                kSecAttrService: Constants.keyTag,
                 kSecAttrGeneric: attributes,
             ])
 
@@ -294,7 +295,7 @@ extension SecureEnclave.Store {
 
     enum Constants {
         static let keyClass = kSecClassGenericPassword as String
-        static let keyTag = Data("com.maxgoedjen.secretive.secureenclave.key".utf8)
+        static let keyTag = "com.maxgoedjen.secretive.secureenclave.key"
         static let notificationToken = UUID().uuidString
     }
     


### PR DESCRIPTION
`kSecAttrService` takes a `CFString` value not `CFData`, this was being bridged automatically in most cases but not in `SecItemUpdate`, where it crashes. 