### PR TITLE
Fix secret list not updating after rename

### DIFF
--- a/Sources/Packages/Sources/SecureEnclaveSecretKit/SecureEnclaveSecret.swift
+++ b/Sources/Packages/Sources/SecureEnclaveSecretKit/SecureEnclaveSecret.swift
@@ -23,10 +23,6 @@ extension SecureEnclave {
             self.attributes = attributes
         }
 
-        public static func ==(lhs: Self, rhs: Self) -> Bool {
-            lhs.id == rhs.id
-        }
-
     }
 
 }

--- a/Sources/Secretive/Views/Secrets/StoreListView.swift
+++ b/Sources/Secretive/Views/Secrets/StoreListView.swift
@@ -21,7 +21,6 @@ struct StoreListView: View {
 
     private func secretRenamed(secret: AnySecret) {
         // Pull new version from store, so we get all updated attributes
-        selection = nil
         selection = storeList.allSecrets.first(where: { $0.id == secret.id }).map(StoreListSelection.secret)
     }
 


### PR DESCRIPTION
Renaming a secret left the sidebar list showing the old name until some unrelated re-render happened.

Fix is to drop that `==` override and let `SecureEnclave.Secret` use normal full-field equality, same as `SmartCard.Secret` already does. Also removed the `selection = nil` in `StoreListView` since it's not needed anymore.